### PR TITLE
[#2] [✨FEATURE] 관리자 - 대기 관리 페이지 마크업 및 스타일링

### DIFF
--- a/src/components/waitingManagement/WaitingHeader.tsx
+++ b/src/components/waitingManagement/WaitingHeader.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { styled } from 'styled-components';
+
+function WaitingHeader() {
+	return (
+		<WaitingHeaderWrapper>
+			<img src={process.env.PUBLIC_URL + '/assets/admin/back_light.svg'} alt="뒤로가기 버튼" />
+			<HeaderTitle>대기 관리</HeaderTitle>
+		</WaitingHeaderWrapper>
+	);
+}
+
+export default WaitingHeader;
+
+const WaitingHeaderWrapper = styled.div`
+	height: 80px;
+	width: 1194px;
+	padding-left: 33px;
+	padding-right: 33px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	font-size: ${({ theme }) => theme.fontSize['4xl']};
+	font-weight: ${({ theme }) => theme.fontWeight.semibold};
+	background-color: ${({ theme }) => theme.textColor.white};
+`;
+
+const HeaderTitle = styled.h1`
+	width: 1101px;
+	padding-right: 25px;
+	display: flex;
+	justify-content: center;
+`;

--- a/src/components/waitingManagement/WaitingHeader.tsx
+++ b/src/components/waitingManagement/WaitingHeader.tsx
@@ -4,7 +4,9 @@ import { styled } from 'styled-components';
 function WaitingHeader() {
 	return (
 		<WaitingHeaderWrapper>
-			<img src={process.env.PUBLIC_URL + '/assets/admin/back_light.svg'} alt="뒤로가기 버튼" />
+			<button>
+				<img src={process.env.PUBLIC_URL + '/assets/admin/back_light.svg'} alt="뒤로가기 버튼" />
+			</button>
 			<HeaderTitle>대기 관리</HeaderTitle>
 		</WaitingHeaderWrapper>
 	);

--- a/src/components/waitingManagement/WaitingHeader.tsx
+++ b/src/components/waitingManagement/WaitingHeader.tsx
@@ -4,9 +4,9 @@ import { styled } from 'styled-components';
 function WaitingHeader() {
 	return (
 		<WaitingHeaderWrapper>
-			<button>
-				<img src={process.env.PUBLIC_URL + '/assets/admin/back_light.svg'} alt="뒤로가기 버튼" />
-			</button>
+			<IconWrapper>
+				<img alt="뒤로가기 버튼" />
+			</IconWrapper>
 			<HeaderTitle>대기 관리</HeaderTitle>
 		</WaitingHeaderWrapper>
 	);
@@ -24,7 +24,15 @@ const WaitingHeaderWrapper = styled.div`
 	align-items: center;
 	font-size: ${({ theme }) => theme.fontSize['4xl']};
 	font-weight: ${({ theme }) => theme.fontWeight.semibold};
-	background-color: ${({ theme }) => theme.textColor.white};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : theme.darkColor?.background)};
+	color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : theme.textColor.white)};
+`;
+
+const IconWrapper = styled.button`
+	img {
+		content: ${({ theme }) =>
+			theme.lightColor ? 'url(/assets/admin/back_light.svg)' : ' url(/assets/admin/back_dark.svg)'};
+	}
 `;
 
 const HeaderTitle = styled.h1`

--- a/src/components/waitingManagement/WaitingItem.tsx
+++ b/src/components/waitingManagement/WaitingItem.tsx
@@ -25,7 +25,6 @@ const WaitingItemWrapper = styled.tr`
 	height: 72px;
 	border-radius: 10px;
 	display: flex;
-	/* justify-content: space-between; */
 	align-items: center;
 	padding-left: 40px;
 	padding-right: 30px;

--- a/src/components/waitingManagement/WaitingItem.tsx
+++ b/src/components/waitingManagement/WaitingItem.tsx
@@ -20,7 +20,9 @@ function WaitingItem() {
 export default WaitingItem;
 
 const WaitingItemWrapper = styled.tr`
-	background-color: ${({ theme }) => theme.textColor.white};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : theme.darkColor?.background)};
+	color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : theme.textColor.white)};
+	border: ${({ theme }) => (theme.lightColor ? 'none' : `1px solid ${theme.textColor.white}`)};
 	width: 982px;
 	height: 72px;
 	border-radius: 10px;
@@ -51,12 +53,12 @@ const ShortBtn = styled.button`
 	height: 48px;
 	margin-right: 14px;
 	border-radius: 10px;
-	background-color: ${({ theme }) => theme.lightColor?.yellow.sub};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.lightColor?.yellow.sub : theme.darkColor?.main)};
 `;
 
 const LongBtn = styled.button`
 	width: 113px;
 	height: 48px;
 	border-radius: 10px;
-	background-color: ${({ theme }) => theme.lightColor?.yellow.sub};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.lightColor?.yellow.sub : theme.darkColor?.main)};
 `;

--- a/src/components/waitingManagement/WaitingItem.tsx
+++ b/src/components/waitingManagement/WaitingItem.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { styled } from 'styled-components';
+
+function WaitingItem() {
+	return (
+		<WaitingItemWrapper>
+			<td width={'130px'}>111번</td>
+			<td width={'110px'}>홍길동동</td>
+			<td width={'120px'}>21명</td>
+			<td width={'250px'}>010-1234-5678</td>
+			<WatingBtnWrapper width={'300px'}>
+				<ShortBtn>알림</ShortBtn>
+				<ShortBtn>취소</ShortBtn>
+				<LongBtn>착석 완료</LongBtn>
+			</WatingBtnWrapper>
+		</WaitingItemWrapper>
+	);
+}
+
+export default WaitingItem;
+
+const WaitingItemWrapper = styled.tr`
+	background-color: ${({ theme }) => theme.textColor.white};
+	width: 982px;
+	height: 72px;
+	border-radius: 10px;
+	display: flex;
+	/* justify-content: space-between; */
+	align-items: center;
+	padding-left: 40px;
+	padding-right: 30px;
+	margin: 0 auto;
+	margin-bottom: 12px;
+	font-size: ${({ theme }) => theme.fontSize['2xl']};
+
+	td {
+		display: flex;
+		justify-content: center;
+	}
+`;
+
+const WatingBtnWrapper = styled.td`
+	width: 300px;
+	height: 48px;
+	color: ${({ theme }) => theme.textColor.white};
+	display: flex;
+	justify-content: center;
+`;
+
+const ShortBtn = styled.button`
+	width: 65px;
+	height: 48px;
+	margin-right: 14px;
+	border-radius: 10px;
+	background-color: ${({ theme }) => theme.lightColor?.yellow.sub};
+`;
+
+const LongBtn = styled.button`
+	width: 113px;
+	height: 48px;
+	border-radius: 10px;
+	background-color: ${({ theme }) => theme.lightColor?.yellow.sub};
+`;

--- a/src/components/waitingManagement/WaitingModal.tsx
+++ b/src/components/waitingManagement/WaitingModal.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { styled } from 'styled-components';
+
+function WaitingModal() {
+	return (
+		<WaitingModalWrapper>
+			<h1>대기를 취소하시겠습니까?</h1>
+			<ModalBtnWrapper>
+				<ModalBtn>예</ModalBtn>
+				<ModalBtn>아니오</ModalBtn>
+			</ModalBtnWrapper>
+		</WaitingModalWrapper>
+	);
+}
+
+export default WaitingModal;
+
+const WaitingModalWrapper = styled.div`
+	width: 622px;
+	height: 454px;
+	border-radius: 15px;
+	display: flex;
+	flex-flow: column nowrap;
+	justify-content: center;
+	align-items: center;
+
+	h1 {
+		font-size: ${({ theme }) => theme.fontSize['3xl']};
+		font-weight: ${({ theme }) => theme.fontWeight.semibold};
+		margin-bottom: 90px;
+		margin-top: 80px;
+	}
+`;
+
+const ModalBtnWrapper = styled.div`
+	width: 289px;
+	height: 65px;
+	display: flex;
+	justify-content: space-between;
+`;
+
+const ModalBtn = styled.button`
+	width: 110px;
+	height: 65px;
+	background-color: ${({ theme }) => theme.lightColor?.yellow.sub};
+	border-radius: 10px;
+	color: ${({ theme }) => theme.textColor.white};
+	font-size: ${({ theme }) => theme.fontSize['3xl']};
+	font-weight: ${({ theme }) => theme.fontWeight.semibold};
+`;

--- a/src/components/waitingManagement/WaitingModal.tsx
+++ b/src/components/waitingManagement/WaitingModal.tsx
@@ -23,6 +23,8 @@ const WaitingModalWrapper = styled.div`
 	flex-flow: column nowrap;
 	justify-content: center;
 	align-items: center;
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : theme.darkColor?.background)};
+	color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : theme.textColor.white)};
 
 	h1 {
 		font-size: ${({ theme }) => theme.fontSize['3xl']};
@@ -42,7 +44,7 @@ const ModalBtnWrapper = styled.div`
 const ModalBtn = styled.button`
 	width: 110px;
 	height: 65px;
-	background-color: ${({ theme }) => theme.lightColor?.yellow.sub};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.lightColor?.yellow.sub : theme.darkColor?.main)};
 	border-radius: 10px;
 	color: ${({ theme }) => theme.textColor.white};
 	font-size: ${({ theme }) => theme.fontSize['3xl']};

--- a/src/pages/admin/WaitingManagement.tsx
+++ b/src/pages/admin/WaitingManagement.tsx
@@ -14,11 +14,11 @@ const WaitingManagement = () => {
 			<WaitingTableWrapper>
 				<TableMenu>
 					<ListWrapper>
-						<WaitingList>
+						<WaitingList role="button" tabIndex={0} aria-label="대기 중 명단 선택하기">
 							<img src={process.env.PUBLIC_URL + '/assets/admin/check-able_light.svg'} alt="선택된 체크 버튼" />
 							대기 중 명단
 						</WaitingList>
-						<WaitedList>
+						<WaitedList role="button" tabIndex={0} aria-label="대기 완료 명단 선택하기">
 							<img
 								src={process.env.PUBLIC_URL + '/assets/admin/check-disable_light.svg'}
 								alt="선택되지 않은 체크 버튼"

--- a/src/pages/admin/WaitingManagement.tsx
+++ b/src/pages/admin/WaitingManagement.tsx
@@ -154,7 +154,6 @@ const TableHeader = styled.tr`
 	font-weight: ${({ theme }) => theme.fontWeight.semibold};
 	border-radius: 15px;
 	display: flex;
-	/* justify-content: space-around; */
 	align-items: center;
 	margin: 0 32px 15px 32px;
 	padding-left: 32px;

--- a/src/pages/admin/WaitingManagement.tsx
+++ b/src/pages/admin/WaitingManagement.tsx
@@ -1,11 +1,173 @@
 import React from 'react';
+import { styled } from 'styled-components';
+import WaitingHeader from '../../components/waitingManagement/WaitingHeader';
+import WaitingItem from '../../components/waitingManagement/WaitingItem';
+
+interface ThProps {
+	width?: string;
+}
 
 const WaitingManagement = () => {
 	return (
-		<div>
-			<h1>대기 관리</h1>
-		</div>
+		<WaitingManagementWrapper>
+			<WaitingHeader />
+			<WaitingTableWrapper>
+				<TableMenu>
+					<ListWrapper>
+						<WaitingList>
+							<img src={process.env.PUBLIC_URL + '/assets/admin/check-able_light.svg'} alt="선택된 체크 버튼" />
+							대기 중 명단
+						</WaitingList>
+						<WaitedList>
+							<img
+								src={process.env.PUBLIC_URL + '/assets/admin/check-disable_light.svg'}
+								alt="선택되지 않은 체크 버튼"
+							/>
+							대기 완료 명단
+						</WaitedList>
+					</ListWrapper>
+					<WaitingBtnWrapper>
+						<WaitingAbleBtn>대기 가능</WaitingAbleBtn>
+						<WaitingDisableBtn>대기 마감</WaitingDisableBtn>
+					</WaitingBtnWrapper>
+				</TableMenu>
+				<TableBox>
+					<table>
+						<thead>
+							<TableHeader>
+								<ThCell width="140px">대기 번호</ThCell>
+								<ThCell width="110px">이름</ThCell>
+								<ThCell width="125px">인원</ThCell>
+								<ThCell width="250px">전화번호</ThCell>
+								<ThCell width="300px">
+									현재 대기 <span>649</span>팀
+								</ThCell>
+							</TableHeader>
+						</thead>
+						<WaitingItemList>
+							<WaitingItem />
+							<WaitingItem />
+							<WaitingItem />
+						</WaitingItemList>
+					</table>
+				</TableBox>
+			</WaitingTableWrapper>
+		</WaitingManagementWrapper>
 	);
 };
 
 export default WaitingManagement;
+
+const WaitingManagementWrapper = styled.div`
+	width: 1194px;
+	height: 834px;
+	background-color: ${({ theme }) => theme.textColor.white};
+`;
+
+const WaitingTableWrapper = styled.div`
+	width: 1046px;
+	height: 697px;
+	background-color: #fff;
+	margin-left: 74px;
+	margin-right: 74px;
+	margin-top: 9px;
+	margin-bottom: 48px;
+`;
+
+const TableMenu = styled.div`
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 1046px;
+	height: 72px;
+`;
+
+const ListWrapper = styled.div`
+	display: flex;
+	justify-content: space-between;
+	width: 352px;
+	font-size: ${({ theme }) => theme.fontSize['2xl']};
+	font-weight: ${({ theme }) => theme.fontWeight.semibold};
+	height: 32px;
+`;
+
+const WaitingList = styled.p`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	img {
+		margin-right: 10px;
+	}
+`;
+
+const WaitedList = styled.p`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	color: ${({ theme }) => theme.textColor.darkgray};
+	img {
+		margin-right: 10px;
+	}
+`;
+
+const WaitingBtnWrapper = styled.div`
+	width: 284px;
+	height: 64px;
+	font-size: ${({ theme }) => theme.fontSize['2xl']};
+	font-weight: ${({ theme }) => theme.fontWeight.bold};
+`;
+
+const WaitingAbleBtn = styled.button`
+	width: 137px;
+	height: 54px;
+	background-color: ${({ theme }) => theme.lightColor?.yellow.point};
+	color: ${({ theme }) => theme.textColor.white};
+	border-radius: 10px;
+	margin-right: 8px;
+`;
+
+const WaitingDisableBtn = styled.button`
+	width: 137px;
+	height: 54px;
+	border-radius: 10px;
+	border: 2px solid ${({ theme }) => theme.lightColor?.yellow.point};
+	color: ${({ theme }) => theme.lightColor?.yellow.point};
+`;
+
+const TableBox = styled.div`
+	width: 1046px;
+	height: 625px;
+	margin-bottom: 48px;
+	padding-top: 20px;
+	background-color: ${({ theme }) => theme.lightColor?.yellow.background};
+`;
+
+// eslint-disable-next-line prettier/prettier
+const ThCell = styled.th<ThProps>`
+	width: ${({ width }) => width};
+`;
+
+const TableHeader = styled.tr`
+	width: 982px;
+	height: 68px;
+	font-size: ${({ theme }) => theme.fontSize['2xl']};
+	font-weight: ${({ theme }) => theme.fontWeight.semibold};
+	border-radius: 15px;
+	display: flex;
+	/* justify-content: space-around; */
+	align-items: center;
+	margin: 0 32px 15px 32px;
+	padding-left: 32px;
+	padding-right: 40px;
+	background-color: ${({ theme }) => theme.lightColor?.yellow.main};
+
+	span {
+		color: ${({ theme }) => theme.textColor.darkbrown};
+	}
+`;
+
+const WaitingItemList = styled.tbody`
+	width: 982px;
+	height: 470px;
+	margin: 0 0 32px 32px;
+`;

--- a/src/pages/admin/WaitingManagement.tsx
+++ b/src/pages/admin/WaitingManagement.tsx
@@ -62,6 +62,7 @@ const WaitingManagementWrapper = styled.div`
 	width: 1194px;
 	height: 834px;
 	background-color: ${({ theme }) => theme.textColor.white};
+	user-select: none;
 `;
 
 const WaitingTableWrapper = styled.div`

--- a/src/pages/admin/WaitingManagement.tsx
+++ b/src/pages/admin/WaitingManagement.tsx
@@ -15,7 +15,7 @@ const WaitingManagement = () => {
 				<TableMenu>
 					<ListWrapper>
 						<WaitingList role="button" tabIndex={0} aria-label="대기 중 명단 선택하기">
-							<img src={process.env.PUBLIC_URL + '/assets/admin/check-able_light.svg'} alt="선택된 체크 버튼" />
+							<img alt="선택된 체크 버튼" />
 							대기 중 명단
 						</WaitingList>
 						<WaitedList role="button" tabIndex={0} aria-label="대기 완료 명단 선택하기">
@@ -61,14 +61,14 @@ export default WaitingManagement;
 const WaitingManagementWrapper = styled.div`
 	width: 1194px;
 	height: 834px;
-	background-color: ${({ theme }) => theme.textColor.white};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : theme.darkColor?.background)};
 	user-select: none;
 `;
 
 const WaitingTableWrapper = styled.div`
 	width: 1046px;
 	height: 697px;
-	background-color: #fff;
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : theme.darkColor?.background)};
 	margin-left: 74px;
 	margin-right: 74px;
 	margin-top: 9px;
@@ -96,8 +96,11 @@ const WaitingList = styled.p`
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : theme.textColor.white)};
 	img {
 		margin-right: 10px;
+		content: ${({ theme }) =>
+			theme.lightColor ? 'url(/assets/admin/check-able_light.svg)' : ' url(/assets/admin/check-able_dark.svg)'};
 	}
 `;
 
@@ -121,7 +124,7 @@ const WaitingBtnWrapper = styled.div`
 const WaitingAbleBtn = styled.button`
 	width: 137px;
 	height: 54px;
-	background-color: ${({ theme }) => theme.lightColor?.yellow.point};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.lightColor?.yellow.point : theme.textColor.darkgray)};
 	color: ${({ theme }) => theme.textColor.white};
 	border-radius: 10px;
 	margin-right: 8px;
@@ -131,8 +134,9 @@ const WaitingDisableBtn = styled.button`
 	width: 137px;
 	height: 54px;
 	border-radius: 10px;
-	border: 2px solid ${({ theme }) => theme.lightColor?.yellow.point};
-	color: ${({ theme }) => theme.lightColor?.yellow.point};
+	border: ${({ theme }) =>
+		theme.lightColor ? `2px solid ${theme.lightColor?.yellow.point}` : `2px solid ${theme.textColor.darkgray}`};
+	color: ${({ theme }) => (theme.lightColor ? theme.lightColor?.yellow.point : theme.textColor.darkgray)};
 `;
 
 const TableBox = styled.div`
@@ -140,7 +144,9 @@ const TableBox = styled.div`
 	height: 625px;
 	margin-bottom: 48px;
 	padding-top: 20px;
-	background-color: ${({ theme }) => theme.lightColor?.yellow.background};
+	background-color: ${({ theme }) =>
+		theme.lightColor ? theme.lightColor?.yellow.background : theme.darkColor?.background};
+	border: ${({ theme }) => (theme.lightColor ? 'none' : `1px solid ${theme.textColor.white}`)};
 `;
 
 // eslint-disable-next-line prettier/prettier
@@ -159,10 +165,10 @@ const TableHeader = styled.tr`
 	margin: 0 32px 15px 32px;
 	padding-left: 32px;
 	padding-right: 40px;
-	background-color: ${({ theme }) => theme.lightColor?.yellow.main};
-
+	background-color: ${({ theme }) => (theme.lightColor ? theme.lightColor.yellow.main : theme.textColor.white)};
+	border: ${({ theme }) => (theme.lightColor ? 'none' : '1px solid white')};
 	span {
-		color: ${({ theme }) => theme.textColor.darkbrown};
+		color: ${({ theme }) => (theme.lightColor ? theme.textColor.darkbrown : theme.darkColor?.sub)};
 	}
 `;
 

--- a/src/style/global.ts
+++ b/src/style/global.ts
@@ -17,6 +17,10 @@ export const GlobalStyles = createGlobalStyle`
     padding: 0;
     font-family: Pretendard;
     min-width: 320px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #eeeeee;
   }
 
   a {

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -55,9 +55,9 @@ export const defaultTheme: DefaultTheme = {
 
 export const darkTheme: DefaultTheme = {
 	darkColor: {
-		background: '#D1EFFE',
-		main: '#4B9AD3',
-		sub: ' #0070c0',
+		background: '#222222',
+		main: '#068fff',
+		sub: ' #4e4feb',
 		point: '#00b0f0',
 	},
 	textColor: {


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->
close #2 

## ✨ 구현 기능 명세
- 대기 관리 페이지 컴포넌트 분리 및 스타일링 작업
- 대기 관리 페이지 마크업 및 스타일 적용
- `global.ts`에 body 스타일 추가
- (07/24) 모달창 마크업 및 스타일링 적용
- (07/24) 탭 접근성 및 aria-label 추가
- (07/24) 다크 모드 적용

## 🎁 PR Point
- table th-td의 위치가 잘 맞는지 체크
- 왜 인지,, `WaitingManagement.tsx`에서 th에 width를 주려니 타입 에러가 나서 인터페이스를 만들어서 작업을 했는데 올바르게 사용한 건지 확신이 서지 않아요..😢 
- 위 작업을 진행할 때 <ThCell> 스타일드 컴포넌트를 만들어서 작업을 했는데 또 eslint 에러가 나서 
`// eslint-disable-next-line prettier/prettier`을 추가했습니다.

## 🕰 소요 시간
- 대략 네 시간

## 😭 어려웠던 점
- 테이블 위치 맞추기가 가장 까다로웠다.
- 오랜만에 git-flow 방식으로 작업하니 적응이 안돼서 실수 할까 봐 호달달 떨면서 했다.

<br/>