### PR TITLE
[🔨 refactor] 대기 관리 recoil 추가 및 머지 시 생겼던 오류 해결

### DIFF
--- a/src/components/MenuItem.tsx
+++ b/src/components/MenuItem.tsx
@@ -28,7 +28,6 @@ function MenuItem() {
 
 export default MenuItem;
 
-
 const Layout = styled.div`
 	display: grid;
 	grid-template-columns: 1fr 1fr 1fr;

--- a/src/components/MenuManagement/CategoryManagementModal.tsx
+++ b/src/components/MenuManagement/CategoryManagementModal.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, useCallback, useState } from 'react';
 import { styled } from 'styled-components';
 import CategoryItem from './CategoryItem';
-import { ModalDefaultType } from '../../state/ModalOpen';
+import { ModalDefaultType } from '../../types/ModalOpenTypes';
 import { db } from '../../firebase/firebaseConfig';
 import { addDoc, collection } from 'firebase/firestore';
 function CategoryManagementModal({ onClickToggleModal }: ModalDefaultType) {

--- a/src/components/waitingManagement/WaitingItem.tsx
+++ b/src/components/waitingManagement/WaitingItem.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { styled } from 'styled-components';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { modalItemId, modalState, modalTypeState, modalUpdateState } from '../../state/modalState';
+import { modalItemId, modalState, modalTypeState, modalUpdateState } from '../../state/ModalState';
 import { WaitingDataType } from '../../types/waitingDataType';
 import { db } from '../../firebase/firebaseConfig';
 import { updateDoc, doc } from 'firebase/firestore';

--- a/src/components/waitingManagement/WaitingModal.tsx
+++ b/src/components/waitingManagement/WaitingModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { styled } from 'styled-components';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { modalState, modalTypeState, modalUpdateState } from '../../state/modalState';
+import { modalState, modalTypeState, modalUpdateState } from '../../state/ModalState';
 
 type modalProps = {
 	closeModal?: () => void;

--- a/src/pages/admin/WaitingManagement.tsx
+++ b/src/pages/admin/WaitingManagement.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { styled, useTheme } from 'styled-components';
 import { Routes, Route, NavLink } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
-import { modalState } from '../../state/modalState';
+import { modalState } from '../../state/ModalState';
+import { isWaitingState } from '../../state/WaitingState';
 
 import WaitingHeader from '../../components/waitingManagement/WaitingHeader';
 import WaitingTableBox from '../../components/waitingManagement/WaitingTableBox';
@@ -13,7 +14,6 @@ type DataStatusProps = {
 };
 
 const WaitingManagement = () => {
-	const [isWaiting, setIsWaiting] = useState<boolean>(true);
 	const [isOpenModal, setIsOpenModal] = useRecoilState<boolean>(modalState);
 
 	const closeModal = () => {
@@ -22,12 +22,14 @@ const WaitingManagement = () => {
 
 	const theme = useTheme();
 
+	const [isWaiting, setIsWaiting] = useRecoilState<boolean>(isWaitingState);
+
 	useEffect(() => {
 		const storedIsWaiting = localStorage.getItem('isWaiting');
 		if (storedIsWaiting != null) {
 			setIsWaiting(JSON.parse(storedIsWaiting));
 		}
-	}, []);
+	}, [setIsWaiting]);
 
 	const handleIsWaitingChange = (newIsWaiting: boolean) => {
 		setIsWaiting(newIsWaiting);

--- a/src/state/Mode.ts
+++ b/src/state/Mode.ts
@@ -1,6 +1,5 @@
 import { atom } from 'recoil';
 
-
 export const selectedModeState = atom<string>({
 	key: 'selectedModeState',
 	default: '',

--- a/src/state/WaitingState.ts
+++ b/src/state/WaitingState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const isWaitingState = atom<boolean>({
+	key: 'isWaiting',
+	default: true,
+});


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

## ✨ 구현 기능 명세
- 지난 머지 시 `menuItem.tsx`와 `Mode.ts`에 들어간 공백문자 삭제
- `CategoryManagementModal.tsx`에서 잘못된 import 수정
- useState로 관리되던 `isWaiting`값을 리코일로 관리.
- ` WaitingState.ts` 추가 및 `ModalState.ts` 이름 변경
- 이름 변경에 따른 import 변경

## 🎁 PR Point
pull했을 때 에러가 나는 부분 없는 지 다시 한번 체크 부탁드립니다!

## 🕰 소요시간
15분

## 😭 어려웠던 점
없음
