### PR TITLE
[#30][FEATURE] 관리자 - 카테고리 추가, 수정, 삭제 기능 수정

### DIFF
--- a/src/components/MenuManagement/CategoryItem.tsx
+++ b/src/components/MenuManagement/CategoryItem.tsx
@@ -4,12 +4,23 @@ import { useRecoilValue } from 'recoil';
 import { categoryListState } from '../../state/CategoryList';
 import { db } from '../../firebase/firebaseConfig';
 import { deleteDoc, collection, getDocs, query, where, updateDoc } from 'firebase/firestore';
+import { menuListState } from '../../state/MenuListState';
 
 function CategoryItem() {
 	const categoryListRef = collection(db, 'categoryList');
 	const categoryList = useRecoilValue(categoryListState);
+	const menuList = useRecoilValue(menuListState);
 	const [editedCategoryName, setEditedCategoryName] = useState<string>('');
 	const [selectedId, setSelectedId] = useState<number>(0);
+
+	const checkDisabled = useCallback(
+		(id: number) => {
+			const currentCategory = categoryList.filter((category) => category.id === id)[0];
+			const isContain = menuList.some((menu) => menu.category === currentCategory.category);
+			return isContain;
+		},
+		[categoryList, menuList],
+	);
 
 	const handleDeleteCategory = useCallback(
 		async (id: number) => {
@@ -21,14 +32,14 @@ function CategoryItem() {
 		[categoryListRef],
 	);
 
-	const handleEditCategoryName = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+	const handleEditCategoryName = (e: ChangeEvent<HTMLInputElement>) => {
 		setEditedCategoryName(e.target.value);
-	}, []);
+	};
 
-	const handleClickEditButton = useCallback((id: number) => {
+	const handleClickEditButton = (id: number) => {
 		setEditedCategoryName('');
 		setSelectedId(id);
-	}, []);
+	};
 
 	const handleStoreEdit = useCallback(
 		async (id: number) => {
@@ -47,9 +58,9 @@ function CategoryItem() {
 		[categoryListRef, editedCategoryName],
 	);
 
-	const handleDeleteEdit = useCallback(() => {
+	const handleDeleteEdit = () => {
 		setSelectedId(0);
-	}, []);
+	};
 
 	return (
 		<>
@@ -78,6 +89,7 @@ function CategoryItem() {
 							</EditCategoryButton>
 							<button
 								type="button"
+								disabled={checkDisabled(id) ? true : false}
 								onClick={() => {
 									handleDeleteCategory(id);
 								}}
@@ -121,6 +133,11 @@ const CategoryItemWrapper = styled.li`
 		border-radius: 10px;
 		font-size: ${({ theme }) => theme.fontSize['2xl']};
 		font-weight: ${({ theme }) => theme.fontWeight.regular};
+
+		&:disabled {
+			cursor: not-allowed;
+			background-color: ${({ theme }) => theme.textColor.darkgray};
+		}
 	}
 `;
 

--- a/src/components/MenuManagement/CategoryList.tsx
+++ b/src/components/MenuManagement/CategoryList.tsx
@@ -40,9 +40,8 @@ export const NavWrapper = styled.nav`
 	button {
 		font-size: ${({ theme }) => theme.fontSize['4xl']};
 		color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : theme.textColor.white)};
-		width: 123px;
 		height: 60px;
-		margin-right: 10px;
+		margin-right: 50px;
 	}
 
 	li.is-selected button {

--- a/src/components/MenuManagement/CategoryManagementModal.tsx
+++ b/src/components/MenuManagement/CategoryManagementModal.tsx
@@ -4,14 +4,29 @@ import CategoryItem from './CategoryItem';
 import { ModalDefaultType } from '../../types/ModalOpenTypes';
 import { db } from '../../firebase/firebaseConfig';
 import { addDoc, collection } from 'firebase/firestore';
+import { useRecoilValue } from 'recoil';
+import { categoryListState } from '../../state/CategoryList';
 function CategoryManagementModal({ onClickToggleModal }: ModalDefaultType) {
 	const [categoryName, setCategoryName] = useState<string>('');
-
+	const [isDuplicate, setIsDuplicate] = useState<boolean>(false);
 	const categoryListRef = collection(db, 'categoryList');
+	const categoryList = useRecoilValue(categoryListState);
 
-	const handleChangeCategoryName = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+	const checkDuplicate = useCallback(
+		(categoryName: string) => {
+			setIsDuplicate(false);
+			const categoryNameList = categoryList.map((category) => category.category);
+			if (categoryNameList.includes(categoryName)) {
+				setIsDuplicate(true);
+			}
+		},
+		[categoryList],
+	);
+
+	const handleChangeCategoryName = (e: ChangeEvent<HTMLInputElement>) => {
 		setCategoryName(e.target.value);
-	}, []);
+		checkDuplicate(e.target.value);
+	};
 
 	const handleAddCategory = useCallback(async () => {
 		if (categoryName.trim()) {
@@ -23,13 +38,14 @@ function CategoryManagementModal({ onClickToggleModal }: ModalDefaultType) {
 	return (
 		<CategoryManagementWrapper>
 			<CategoryModalContent>
+				<GuidText>* 이미 존재하는 카테고리는 추가 불가능합니다.</GuidText>
 				<AddContainer>
 					<input type="text" value={categoryName} onChange={handleChangeCategoryName} />
-					<button type="button" onClick={handleAddCategory} disabled={!categoryName ? true : false}>
+					<button type="button" onClick={handleAddCategory} disabled={!categoryName || isDuplicate ? true : false}>
 						추가
 					</button>
 				</AddContainer>
-				<GuidText>메뉴가 포함된 카테고리는 삭제 불가능합니다.</GuidText>
+				<GuidText>* 메뉴가 포함된 카테고리는 삭제 불가능합니다.</GuidText>
 				<ul>
 					<CategoryItem />
 				</ul>
@@ -63,7 +79,7 @@ const CategoryModalContent = styled.div`
 	display: flex;
 	flex-direction: column;
 	align-items: start;
-	padding: 50px 0 0 58px;
+	padding: 30px 0 0 58px;
 
 	ul {
 		display: flex;
@@ -118,6 +134,6 @@ const CloseButton = styled.button`
 `;
 
 const GuidText = styled.p`
-	color: red;
-	margin-bottom: 20px;
+	color: ${({ theme }) => theme.textColor.black};
+	margin-bottom: 10px;
 `;

--- a/src/components/MenuManagement/CategoryManagementModal.tsx
+++ b/src/components/MenuManagement/CategoryManagementModal.tsx
@@ -29,6 +29,7 @@ function CategoryManagementModal({ onClickToggleModal }: ModalDefaultType) {
 						추가
 					</button>
 				</AddContainer>
+				<GuidText>메뉴가 포함된 카테고리는 삭제 불가능합니다.</GuidText>
 				<ul>
 					<CategoryItem />
 				</ul>
@@ -114,4 +115,9 @@ const CloseButton = styled.button`
 	border-radius: 10px;
 	font-size: ${({ theme }) => theme.fontSize['3xl']};
 	font-weight: ${({ theme }) => theme.fontWeight.regular};
+`;
+
+const GuidText = styled.p`
+	color: red;
+	margin-bottom: 20px;
 `;

--- a/src/components/MenuManagement/Header.tsx
+++ b/src/components/MenuManagement/Header.tsx
@@ -3,8 +3,10 @@ import styled from 'styled-components';
 import CategoryManagementModal from './CategoryManagementModal';
 import ModalPortal from '../ModalPortal';
 import AddMenuModal from './AddMenuModal';
+import { useNavigate } from 'react-router-dom';
 
 function Header() {
+	const navigate = useNavigate();
 	const [isCategoryModalOpen, setIsCategoryModalOpen] = useState<boolean>(false);
 	const [isAddMenuModalOpen, setIsAddMenuModalOpen] = useState<boolean>(false);
 
@@ -19,7 +21,11 @@ function Header() {
 	return (
 		<>
 			<HeadWrapper>
-				<ImageContainer>
+				<ImageContainer
+					onClick={() => {
+						navigate(-1);
+					}}
+				>
 					<img alt="뒤로가기" />
 				</ImageContainer>
 				<h1>메뉴관리</h1>

--- a/src/components/MenuManagement/MenuList.tsx
+++ b/src/components/MenuManagement/MenuList.tsx
@@ -2,13 +2,20 @@ import React from 'react';
 import styled from 'styled-components';
 import MenuItem from '../MenuItem';
 import { MenuType } from '../../types/menuMangementType';
+import { useRecoilValue } from 'recoil';
+import { selectedCategoryState } from '../../state/CategoryList';
 
 interface ListPropType {
-	list: MenuType[] | null;
+	list: MenuType[];
 }
 
 function MenuList({ list }: ListPropType) {
-	return <MenuListWrapper>{list?.map((item) => <MenuItem key={item.id} menu={item} />)}</MenuListWrapper>;
+	const selectedCategory = useRecoilValue(selectedCategoryState);
+	return (
+		<MenuListWrapper>
+			{list.filter((item) => item.category === selectedCategory)?.map((item) => <MenuItem key={item.id} menu={item} />)}
+		</MenuListWrapper>
+	);
 }
 
 export default MenuList;

--- a/src/pages/admin/MenuManagement.tsx
+++ b/src/pages/admin/MenuManagement.tsx
@@ -1,17 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import Header from '../../components/MenuManagement/Header';
 import CategoryList from '../../components/MenuManagement/CategoryList';
 import MenuList from '../../components/MenuManagement/MenuList';
 import { db } from '../../firebase/firebaseConfig';
 import { collection, onSnapshot, orderBy, query } from 'firebase/firestore';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { categoryListState, selectedCategoryState } from '../../state/CategoryList';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { categoryListState } from '../../state/CategoryList';
 import { CategoryType, MenuType } from '../../types/menuMangementType';
+import { menuListState } from '../../state/MenuListState';
 function MenuManagement() {
-	const selectedCategory = useRecoilValue(selectedCategoryState);
 	const setCategoryList = useSetRecoilState(categoryListState);
-	const [menuList, setMenuList] = useState<MenuType[] | null>([]);
+	const [menuList, setMenuList] = useRecoilState(menuListState);
 
 	useEffect(() => {
 		const fetchCategory = async () => {
@@ -49,13 +49,12 @@ function MenuManagement() {
 						imageName,
 					});
 				});
-				const filteredList = list.filter((item) => item.category === selectedCategory);
-				setMenuList(filteredList);
+				setMenuList(list);
 			});
 			return unsub;
 		};
 		fetchMenu();
-	}, [selectedCategory]);
+	}, [setMenuList]);
 
 	return (
 		<MenuManagementWrapper>

--- a/src/state/MenuListState.ts
+++ b/src/state/MenuListState.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+import { MenuType } from '../types/menuMangementType';
+
+export const menuListState = atom<MenuType[]>({
+	key: 'menuListState',
+	default: [],
+});


### PR DESCRIPTION
close #30 
## ✨ 구현 기능 명세
- 카테고리 목록 추가시 중복된 카테고리 추가 불가능하도록 수정
- 카테고리 목록 수정시 포함된 메뉴의 데이터 category 값 수정되도록 구현
- 카테고리 목록 중 포함된 메뉴가 없는 카테고리만 삭제 가능하도록 수정 

## 🎁 PR Point
- 카테고리 수정시 데이터베이스와 데이터 정보가 일치하는지 체크
- 카테고리 수정 또는 삭제 후 모달 닫았을 떄 메뉴추가 페이지에서 카테고리 리스트 중 특정 카테고리에 포커싱 잘 되는지 체크 

## 🕰 소요시간
약 4시간 

## 😭 어려웠던 점
카테고리 관련 기능은 다 구현 했다고 생각했는데 세세한 부분을 신경쓰지 못해서 전체적으로 수정한 것이 아쉽다. 처음부터 제대로 기획하는 것이 중요하다는 것을 깨달았다. 
