### PR TITLE
[#49][FEATURE] 관리자 - 주문 내역 확인 페이지 기능 구현

### DIFF
--- a/src/components/OrderHistory/Header.tsx
+++ b/src/components/OrderHistory/Header.tsx
@@ -1,10 +1,27 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 
-function Header() {
+interface HeaderPropType {
+	setIsProgress: () => void;
+	setIsComplete: () => void;
+}
+function Header({ setIsProgress, setIsComplete }: HeaderPropType) {
 	const navigate = useNavigate();
+	const progressRef = useRef<HTMLButtonElement>(null);
+	const completeRef = useRef<HTMLButtonElement>(null);
 
+	const handleClickProgress = () => {
+		completeRef.current?.classList.remove('is-selected');
+		progressRef.current?.classList.add('is-selected');
+		setIsProgress();
+	};
+
+	const handleClickComplete = () => {
+		progressRef.current?.classList.remove('is-selected');
+		completeRef.current?.classList.add('is-selected');
+		setIsComplete();
+	};
 	return (
 		<>
 			<HeadWrapper>
@@ -17,10 +34,12 @@ function Header() {
 				</ImageContainer>
 				<h1>주문 내역</h1>
 				<ButtonContainer>
-					<button type="button" className="is-selected">
+					<button type="button" className="is-selected" ref={progressRef} onClick={handleClickProgress}>
 						진행중
 					</button>
-					<button type="button">완료주문</button>
+					<button type="button" ref={completeRef} onClick={handleClickComplete}>
+						완료주문
+					</button>
 				</ButtonContainer>
 			</HeadWrapper>
 		</>

--- a/src/components/OrderHistory/OrderItem.tsx
+++ b/src/components/OrderHistory/OrderItem.tsx
@@ -1,21 +1,25 @@
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 import styled from 'styled-components';
 import { OrderListItemType } from '../../types/orderHistoryType';
 
 interface OrderItemPropType {
+	idx: number;
 	itemInfo: OrderListItemType;
+	toggleComplete: (id: number, checked: boolean) => void;
 }
-function OrderItem({ itemInfo }: OrderItemPropType) {
-	const handleToggleComplete = () => {
-		console.log(itemInfo.isComplete);
+function OrderItem({ idx, itemInfo, toggleComplete }: OrderItemPropType) {
+	const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+		const checked = e.currentTarget.checked;
+		toggleComplete(idx, checked);
 	};
+
 	return (
 		<OrderItemWrapper>
 			<Info>
-				<input type="checkbox" checked={itemInfo.isComplete} onChange={handleToggleComplete} />
+				<input type="checkbox" checked={itemInfo.isComplete} onChange={handleChange} />
 				<span>{itemInfo.quantity}개</span>
 			</Info>
-			<span>{itemInfo.menu}</span>
+			<MenuName className={itemInfo.isComplete ? 'is-checked' : ''}>{itemInfo.menu}</MenuName>
 		</OrderItemWrapper>
 	);
 }
@@ -42,9 +46,17 @@ const Info = styled.div`
 	span {
 		font-size: ${({ theme }) => theme.fontSize['xl']};
 	}
+
 	input {
 		width: 20px;
 		height: 20px;
 		margin-right: 10px;
+	}
+`;
+
+const MenuName = styled.span`
+	&.is-checked {
+		text-decoration: line-through;
+		color: ${({ theme }) => theme.textColor.darkgray};
 	}
 `;

--- a/src/components/OrderHistory/OrderItem.tsx
+++ b/src/components/OrderHistory/OrderItem.tsx
@@ -1,29 +1,50 @@
 import React from 'react';
 import styled from 'styled-components';
-function OrderItem() {
+import { OrderListItemType } from '../../types/orderHistoryType';
+
+interface OrderItemPropType {
+	itemInfo: OrderListItemType;
+}
+function OrderItem({ itemInfo }: OrderItemPropType) {
+	const handleToggleComplete = () => {
+		console.log(itemInfo.isComplete);
+	};
 	return (
 		<OrderItemWrapper>
-			<span>아메리카노</span>
-			<span>1</span>
-			<input type="checkbox" name="" id="" />
+			<Info>
+				<input type="checkbox" checked={itemInfo.isComplete} onChange={handleToggleComplete} />
+				<span>{itemInfo.quantity}개</span>
+			</Info>
+			<span>{itemInfo.menu}</span>
 		</OrderItemWrapper>
 	);
 }
 
 export default OrderItem;
 
-const OrderItemWrapper = styled.div`
-	height: 60px;
+const OrderItemWrapper = styled.li`
 	background-color: ${({ theme }) => theme.textColor.white};
 	border-radius: 10px;
 	margin-bottom: 19px;
-	font-size: ${({ theme }) => theme.fontSize['3xl']};
+	font-size: ${({ theme }) => theme.fontSize['2xl']};
 	display: flex;
-	justify-content: space-around;
-	align-items: center;
+	flex-direction: column;
+	align-items: flex-start;
+	padding: 10px;
 	border: ${({ theme }) => (theme.lightColor ? 'none' : theme.textColor.darkgray)} 1px solid;
+`;
+
+const Info = styled.div`
+	display: flex;
+	align-items: center;
+	margin-bottom: 10px;
+
+	span {
+		font-size: ${({ theme }) => theme.fontSize['xl']};
+	}
 	input {
 		width: 20px;
 		height: 20px;
+		margin-right: 10px;
 	}
 `;

--- a/src/components/OrderHistory/OrderList.tsx
+++ b/src/components/OrderHistory/OrderList.tsx
@@ -1,25 +1,35 @@
 import React from 'react';
 import styled from 'styled-components';
 import OrderItem from './OrderItem';
+import { OrderListType } from '../../types/orderHistoryType';
 
-function OrderList() {
+interface OrderListPropType {
+	orderList: OrderListType[];
+}
+function OrderList({ orderList }: OrderListPropType) {
 	return (
-		<OrderListWrapper>
-			<OrderInfo>
-				<span>#1</span>
-				<span>매장</span>
-			</OrderInfo>
-			<ItemWrapper>
-				<OrderItem />
-			</ItemWrapper>
-			<button type="button">제조완료</button>
-		</OrderListWrapper>
+		<>
+			{orderList.map(({ id, list, takeout }, idx) => (
+				<OrderListWrapper key={id}>
+					<OrderInfo>
+						<span>{`#${idx + 1}`}</span>
+						<span>{takeout ? '포장' : '매장'}</span>
+					</OrderInfo>
+					<ItemWrapper>
+						{list.map((item, idx) => (
+							<OrderItem key={`${id}${idx}`} itemInfo={item} />
+						))}
+					</ItemWrapper>
+					<button type="button">제조완료</button>
+				</OrderListWrapper>
+			))}
+		</>
 	);
 }
 
 export default OrderList;
 
-const OrderListWrapper = styled.div`
+const OrderListWrapper = styled.li`
 	background-color: ${({ theme }) =>
 		theme.lightColor ? theme.lightColor?.yellow.background : theme.darkColor?.background};
 	width: 350px;
@@ -33,10 +43,10 @@ const OrderListWrapper = styled.div`
 		height: 50px;
 		border-radius: 10px;
 		background-color: ${({ theme }) => (theme.lightColor ? theme.lightColor?.yellow.main : theme.darkColor?.main)};
-		font-size: ${({ theme }) => theme.fontSize['3xl']};
+		font-size: ${({ theme }) => theme.fontSize['2xl']};
 		font-weight: ${({ theme }) => theme.fontWeight.semibold};
 		margin-left: 90px;
-		color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : theme.textColor.white)};
+		color: ${({ theme }) => theme.textColor.white};
 	}
 `;
 
@@ -54,7 +64,7 @@ const OrderInfo = styled.div`
 		font-weight: ${({ theme }) => theme.fontWeight.semibold};
 	}
 `;
-const ItemWrapper = styled.div`
+const ItemWrapper = styled.ul`
 	width: 318px;
 	height: 376px;
 	margin-bottom: 19px;

--- a/src/components/OrderHistory/OrderList.tsx
+++ b/src/components/OrderHistory/OrderList.tsx
@@ -4,13 +4,18 @@ import OrderItem from './OrderItem';
 import { OrderListItemType, OrderListType } from '../../types/orderHistoryType';
 import { collection, getDocs, query, updateDoc, where } from 'firebase/firestore';
 import { db } from '../../firebase/firebaseConfig';
+import { changeDateFormat } from '../../utils/changeDateFormat';
 
 interface OrderListPropType {
-	number: number;
 	order: OrderListType;
 }
-function OrderList({ number, order }: OrderListPropType) {
-	const orderRef = collection(db, 'testOrderList');
+function OrderList({ order }: OrderListPropType) {
+	const orderRef = collection(db, 'testOrderList'); //orderList로 수정
+
+	const timeFormat = (id: number) => {
+		const { hour, minute, sec } = changeDateFormat(id);
+		return `${hour}:${minute}:${sec}`;
+	};
 
 	const handleToggleComplete = async (id: number, checked: boolean) => {
 		const orderDocs = await getDocs(query(orderRef, where('id', '==', order.id)));
@@ -39,8 +44,8 @@ function OrderList({ number, order }: OrderListPropType) {
 		<>
 			<OrderListWrapper key={order.id}>
 				<OrderInfo>
-					<span>{`#${number + 1}`}</span>
 					<span>{order.takeout ? '포장' : '매장'}</span>
+					<span>{timeFormat(order.id)}</span>
 				</OrderInfo>
 				<ItemWrapper>
 					{order.list.map((item, idx) => (
@@ -82,14 +87,17 @@ const OrderInfo = styled.div`
 	margin-bottom: 20px;
 	font-size: ${({ theme }) => theme.fontSize['4xl']};
 	color: ${({ theme }) => (theme.lightColor ? 'none' : theme.textColor.white)};
+	display: flex;
+	align-items: center;
 
 	span:first-child {
-		font-weight: ${({ theme }) => theme.fontWeight.regular};
+		font-weight: ${({ theme }) => theme.fontWeight.semibold};
 		margin-right: 11px;
 	}
 
 	span:last-child {
-		font-weight: ${({ theme }) => theme.fontWeight.semibold};
+		font-size: ${({ theme }) => theme.fontSize['xl']};
+		font-weight: ${({ theme }) => theme.fontWeight.regular};
 	}
 `;
 const ItemWrapper = styled.ul`

--- a/src/components/OrderHistory/OrderList.tsx
+++ b/src/components/OrderHistory/OrderList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import OrderItem from './OrderItem';
-import { OrderListType } from '../../types/orderHistoryType';
+import { OrderListItemType, OrderListType } from '../../types/orderHistoryType';
 import { collection, getDocs, query, updateDoc, where } from 'firebase/firestore';
 import { db } from '../../firebase/firebaseConfig';
 
@@ -10,14 +10,27 @@ interface OrderListPropType {
 	order: OrderListType;
 }
 function OrderList({ number, order }: OrderListPropType) {
+	const orderRef = collection(db, 'testOrderList');
+
 	const handleToggleComplete = async (id: number, checked: boolean) => {
-		const orderRef = collection(db, 'testOrderList');
 		const orderDocs = await getDocs(query(orderRef, where('id', '==', order.id)));
 		if (orderDocs.docs.length !== 0) {
 			const docData = orderDocs.docs[0].data();
 			docData.list[id].isComplete = checked;
 			await updateDoc(orderDocs.docs[0].ref, {
 				...docData,
+			});
+		}
+	};
+
+	const handleComplete = async () => {
+		const orderDocs = await getDocs(query(orderRef, where('id', '==', order.id)));
+		if (orderDocs.docs.length !== 0) {
+			const docData = orderDocs.docs[0].data();
+			docData.list.map((item: OrderListItemType) => (item.isComplete = true));
+			await updateDoc(orderDocs.docs[0].ref, {
+				...docData,
+				progress: '완료주문',
 			});
 		}
 	};
@@ -34,7 +47,9 @@ function OrderList({ number, order }: OrderListPropType) {
 						<OrderItem key={`${order.id}${idx}`} idx={idx} itemInfo={item} toggleComplete={handleToggleComplete} />
 					))}
 				</ItemWrapper>
-				<button type="button">제조완료</button>
+				<button type="button" onClick={handleComplete}>
+					제조완료
+				</button>
 			</OrderListWrapper>
 		</>
 	);

--- a/src/components/OrderHistory/OrderList.tsx
+++ b/src/components/OrderHistory/OrderList.tsx
@@ -2,27 +2,40 @@ import React from 'react';
 import styled from 'styled-components';
 import OrderItem from './OrderItem';
 import { OrderListType } from '../../types/orderHistoryType';
+import { collection, getDocs, query, updateDoc, where } from 'firebase/firestore';
+import { db } from '../../firebase/firebaseConfig';
 
 interface OrderListPropType {
-	orderList: OrderListType[];
+	number: number;
+	order: OrderListType;
 }
-function OrderList({ orderList }: OrderListPropType) {
+function OrderList({ number, order }: OrderListPropType) {
+	const handleToggleComplete = async (id: number, checked: boolean) => {
+		const orderRef = collection(db, 'testOrderList');
+		const orderDocs = await getDocs(query(orderRef, where('id', '==', order.id)));
+		if (orderDocs.docs.length !== 0) {
+			const docData = orderDocs.docs[0].data();
+			docData.list[id].isComplete = checked;
+			await updateDoc(orderDocs.docs[0].ref, {
+				...docData,
+			});
+		}
+	};
+
 	return (
 		<>
-			{orderList.map(({ id, list, takeout }, idx) => (
-				<OrderListWrapper key={id}>
-					<OrderInfo>
-						<span>{`#${idx + 1}`}</span>
-						<span>{takeout ? '포장' : '매장'}</span>
-					</OrderInfo>
-					<ItemWrapper>
-						{list.map((item, idx) => (
-							<OrderItem key={`${id}${idx}`} itemInfo={item} />
-						))}
-					</ItemWrapper>
-					<button type="button">제조완료</button>
-				</OrderListWrapper>
-			))}
+			<OrderListWrapper key={order.id}>
+				<OrderInfo>
+					<span>{`#${number + 1}`}</span>
+					<span>{order.takeout ? '포장' : '매장'}</span>
+				</OrderInfo>
+				<ItemWrapper>
+					{order.list.map((item, idx) => (
+						<OrderItem key={`${order.id}${idx}`} idx={idx} itemInfo={item} toggleComplete={handleToggleComplete} />
+					))}
+				</ItemWrapper>
+				<button type="button">제조완료</button>
+			</OrderListWrapper>
 		</>
 	);
 }

--- a/src/components/OrderHistory/OrderListContainer.tsx
+++ b/src/components/OrderHistory/OrderListContainer.tsx
@@ -16,10 +16,9 @@ function OrderListContainer({ isProgressMode }: ContainerPropType) {
 
 	const orderListRef = collection(db, 'testOrderList'); //orderList로 수정
 
-	const fetchInProgress = async () => {
-		const numberToday = Number(new Date(today.year, today.month, today.date));
+	const fetchInProgress = async (today: number) => {
 		const unsub = onSnapshot(
-			query(orderListRef, where('progress', '==', '진행중'), where('id', '>', numberToday), orderBy('id')),
+			query(orderListRef, where('progress', '==', '진행중'), where('id', '>', today), orderBy('id')),
 			(snapshot) => {
 				const inProgress: OrderListType[] = [];
 				snapshot.docs.map((doc) => {
@@ -32,10 +31,9 @@ function OrderListContainer({ isProgressMode }: ContainerPropType) {
 		return unsub;
 	};
 
-	const fetchComplete = async () => {
-		const numberToday = Number(new Date(today.year, today.month, today.date));
+	const fetchComplete = async (today: number) => {
 		const unsub = onSnapshot(
-			query(orderListRef, where('progress', '==', '완료주문'), where('id', '>', numberToday), orderBy('id')),
+			query(orderListRef, where('progress', '==', '완료주문'), where('id', '>', today), orderBy('id')),
 			(snapshot) => {
 				const complete: OrderListType[] = [];
 				snapshot.docs.map((doc) => {
@@ -49,13 +47,12 @@ function OrderListContainer({ isProgressMode }: ContainerPropType) {
 	};
 
 	useEffect(() => {
-		fetchInProgress();
-		fetchComplete();
-	}, []);
-
-	useEffect(() => {
 		const { year, month, date } = changeDateFormat(Date.now());
 		setToday({ year, month, date });
+
+		const todayDate = Number(new Date(year, month, date));
+		fetchInProgress(todayDate);
+		fetchComplete(todayDate);
 	}, []);
 
 	return (

--- a/src/components/OrderHistory/OrderListContainer.tsx
+++ b/src/components/OrderHistory/OrderListContainer.tsx
@@ -1,18 +1,58 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import OrderList from './OrderList';
+import { OrderListType } from '../../types/orderHistoryType';
+import { collection, onSnapshot, query, orderBy, where } from 'firebase/firestore';
+import { db } from '../../firebase/firebaseConfig';
 
-function OrderListContainer() {
+interface ContainerPropType {
+	isProgressMode: boolean;
+}
+function OrderListContainer({ isProgressMode }: ContainerPropType) {
+	const [inProgressList, setInProgressList] = useState<OrderListType[]>([]);
+	const [completeList, setCompleteList] = useState<OrderListType[]>([]);
+
+	const fetchInProgress = async () => {
+		const orderListRef = collection(db, 'testOrderList'); //orderList 완성시 수정
+		const unsub = onSnapshot(query(orderListRef, where('progress', '==', '진행중'), orderBy('id')), (snapshot) => {
+			const inProgress: OrderListType[] = [];
+			snapshot.docs.map((doc) => {
+				const listObj = doc.data() as OrderListType;
+				inProgress.push(listObj);
+			});
+			setInProgressList(inProgress);
+		});
+		return unsub;
+	};
+
+	const fetchComplete = async () => {
+		const orderListRef = collection(db, 'testOrderList'); //orderList 완성시 수정
+		const unsub = onSnapshot(query(orderListRef, where('progress', '==', '완료주문'), orderBy('id')), (snapshot) => {
+			const complete: OrderListType[] = [];
+			snapshot.docs.map((doc) => {
+				const listObj = doc.data() as OrderListType;
+				complete.push(listObj);
+			});
+			setCompleteList(complete);
+		});
+		return unsub;
+	};
+
+	useEffect(() => {
+		fetchInProgress();
+		fetchComplete();
+	}, []);
+
 	return (
 		<OrderListContainerWrapper>
-			<OrderList />
+			{isProgressMode ? <OrderList orderList={inProgressList} /> : <OrderList orderList={completeList} />}
 		</OrderListContainerWrapper>
 	);
 }
 
 export default OrderListContainer;
 
-const OrderListContainerWrapper = styled.div`
+const OrderListContainerWrapper = styled.ul`
 	width: 1072px;
 	margin: 0 auto;
 	display: grid;

--- a/src/components/OrderHistory/OrderListContainer.tsx
+++ b/src/components/OrderHistory/OrderListContainer.tsx
@@ -45,7 +45,19 @@ function OrderListContainer({ isProgressMode }: ContainerPropType) {
 
 	return (
 		<OrderListContainerWrapper>
-			{isProgressMode ? <OrderList orderList={inProgressList} /> : <OrderList orderList={completeList} />}
+			{isProgressMode ? (
+				<>
+					{inProgressList.map((item, idx) => (
+						<OrderList key={item.id} number={idx} order={item} />
+					))}
+				</>
+			) : (
+				<>
+					{completeList.map((item, idx) => (
+						<OrderList key={item.id} number={idx} order={item} />
+					))}
+				</>
+			)}
 		</OrderListContainerWrapper>
 	);
 }

--- a/src/components/OrderHistory/OrderListContainer.tsx
+++ b/src/components/OrderHistory/OrderListContainer.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 import OrderList from './OrderList';
-import { OrderListType } from '../../types/orderHistoryType';
+import { OrderListType, TodayDateType } from '../../types/orderHistoryType';
 import { collection, onSnapshot, query, orderBy, where } from 'firebase/firestore';
 import { db } from '../../firebase/firebaseConfig';
+import { changeDateFormat } from '../../utils/changeDateFormat';
 
 interface ContainerPropType {
 	isProgressMode: boolean;
@@ -11,30 +12,39 @@ interface ContainerPropType {
 function OrderListContainer({ isProgressMode }: ContainerPropType) {
 	const [inProgressList, setInProgressList] = useState<OrderListType[]>([]);
 	const [completeList, setCompleteList] = useState<OrderListType[]>([]);
+	const [today, setToday] = useState<TodayDateType>({ year: 0, month: 0, date: 0 });
+
+	const orderListRef = collection(db, 'testOrderList'); //orderList로 수정
 
 	const fetchInProgress = async () => {
-		const orderListRef = collection(db, 'testOrderList'); //orderList 완성시 수정
-		const unsub = onSnapshot(query(orderListRef, where('progress', '==', '진행중'), orderBy('id')), (snapshot) => {
-			const inProgress: OrderListType[] = [];
-			snapshot.docs.map((doc) => {
-				const listObj = doc.data() as OrderListType;
-				inProgress.push(listObj);
-			});
-			setInProgressList(inProgress);
-		});
+		const numberToday = Number(new Date(today.year, today.month, today.date));
+		const unsub = onSnapshot(
+			query(orderListRef, where('progress', '==', '진행중'), where('id', '>', numberToday), orderBy('id')),
+			(snapshot) => {
+				const inProgress: OrderListType[] = [];
+				snapshot.docs.map((doc) => {
+					const listObj = doc.data() as OrderListType;
+					inProgress.push(listObj);
+				});
+				setInProgressList(inProgress);
+			},
+		);
 		return unsub;
 	};
 
 	const fetchComplete = async () => {
-		const orderListRef = collection(db, 'testOrderList'); //orderList 완성시 수정
-		const unsub = onSnapshot(query(orderListRef, where('progress', '==', '완료주문'), orderBy('id')), (snapshot) => {
-			const complete: OrderListType[] = [];
-			snapshot.docs.map((doc) => {
-				const listObj = doc.data() as OrderListType;
-				complete.push(listObj);
-			});
-			setCompleteList(complete);
-		});
+		const numberToday = Number(new Date(today.year, today.month, today.date));
+		const unsub = onSnapshot(
+			query(orderListRef, where('progress', '==', '완료주문'), where('id', '>', numberToday), orderBy('id')),
+			(snapshot) => {
+				const complete: OrderListType[] = [];
+				snapshot.docs.map((doc) => {
+					const listObj = doc.data() as OrderListType;
+					complete.push(listObj);
+				});
+				setCompleteList(complete);
+			},
+		);
 		return unsub;
 	};
 
@@ -43,33 +53,53 @@ function OrderListContainer({ isProgressMode }: ContainerPropType) {
 		fetchComplete();
 	}, []);
 
+	useEffect(() => {
+		const { year, month, date } = changeDateFormat(Date.now());
+		setToday({ year, month, date });
+	}, []);
+
 	return (
 		<OrderListContainerWrapper>
-			{isProgressMode ? (
-				<>
-					{inProgressList.map((item, idx) => (
-						<OrderList key={item.id} number={idx} order={item} />
-					))}
-				</>
-			) : (
-				<>
-					{completeList.map((item, idx) => (
-						<OrderList key={item.id} number={idx} order={item} />
-					))}
-				</>
-			)}
+			<DateContainer>{`${today.year}년 ${today.month + 1}월 ${today.date}일`}</DateContainer>
+			<ListWrapper>
+				{isProgressMode ? (
+					<>
+						{inProgressList.map((item) => (
+							<OrderList key={item.id} order={item} />
+						))}
+					</>
+				) : (
+					<>
+						{completeList.map((item) => (
+							<OrderList key={item.id} order={item} />
+						))}
+					</>
+				)}
+			</ListWrapper>
 		</OrderListContainerWrapper>
 	);
 }
 
 export default OrderListContainer;
 
-const OrderListContainerWrapper = styled.ul`
+const DateContainer = styled.p`
+	font-size: ${({ theme }) => theme.fontSize['2xl']};
+	font-weight: ${({ theme }) => theme.fontWeight.semibold};
+	color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : theme.textColor.white)};
+`;
+
+const OrderListContainerWrapper = styled.div`
 	width: 1072px;
 	margin: 0 auto;
+	margin-top: 40px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+`;
+const ListWrapper = styled.ul`
 	display: grid;
 	grid-template-columns: repeat(3, 1fr);
 	column-gap: 12px;
 	row-gap: 20px;
-	margin-top: 54px;
+	margin-top: 40px;
 `;

--- a/src/pages/admin/OrderHistory.tsx
+++ b/src/pages/admin/OrderHistory.tsx
@@ -1,12 +1,23 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import Header from '../../components/OrderHistory/Header';
 import OrderListContainer from '../../components/OrderHistory/OrderListContainer';
+
 function OrderHistory() {
+	const [isProgressMode, setIsProgressMode] = useState<boolean>(true);
+
+	const handleIsProgressMode = useCallback(() => {
+		setIsProgressMode(true);
+	}, []);
+
+	const handleIsCompleteMode = useCallback(() => {
+		setIsProgressMode(false);
+	}, []);
+
 	return (
 		<HistoryWrapper>
-			<Header />
-			<OrderListContainer />
+			<Header setIsProgress={handleIsProgressMode} setIsComplete={handleIsCompleteMode} />
+			<OrderListContainer isProgressMode={isProgressMode} />
 		</HistoryWrapper>
 	);
 }

--- a/src/types/orderHistoryType.ts
+++ b/src/types/orderHistoryType.ts
@@ -1,0 +1,13 @@
+export interface OrderListType {
+	id: number;
+	list: OrderListItemType[];
+	progress: string;
+	takeout: boolean;
+}
+
+export interface OrderListItemType {
+	menu: string;
+	isComplete: boolean;
+	quantity: number;
+	totalPrice: number;
+}

--- a/src/types/orderHistoryType.ts
+++ b/src/types/orderHistoryType.ts
@@ -11,3 +11,9 @@ export interface OrderListItemType {
 	quantity: number;
 	totalPrice: number;
 }
+
+export interface TodayDateType {
+	year: number;
+	month: number;
+	date: number;
+}

--- a/src/utils/changeDateFormat.ts
+++ b/src/utils/changeDateFormat.ts
@@ -1,0 +1,11 @@
+export const changeDateFormat = (numberDate: number) => {
+	const newDate = new Date(numberDate);
+	const year = newDate.getFullYear();
+	const month = newDate.getMonth();
+	const date = newDate.getDate();
+	const hour = newDate.getHours();
+	const minute = newDate.getMinutes();
+	const sec = newDate.getSeconds();
+
+	return { year, month, date, hour, minute, sec };
+};


### PR DESCRIPTION
close #49 

## ✨ 구현 기능 명세
- 데이터베이스에서 주문 내역 불러오기
- 메뉴별 완료 표시 가능한 체크박스 기능 
  - 완료된 주문의 경우 스타일 변경 
- 진행중인 주문과 완료 주문 구분
- 오늘 날짜의 주문만 렌더링 
-  진행중인 주문 내역에서 제조 완료 버튼 클릭시 완료주문으로 이동하기

## 🎁 PR Point
임시 데이터로 구현해서 주문 기능 완료되면 데이터베이스 관련 변수명 수정 예정입니다.

## 🕰 소요시간
하루

## 😭 어려웠던 점
카테고리나 메뉴 정보 등의 데이터는 1depth의 객체 형태였는데  주문 내역 데이터 구조는 객체 안 배열에 객체가 있는 형태다. 데이터 구조가 낯설어서 음료 각각의 제조 완료를 표시하기 위한 체크박스 데이터 수정 기능 구현이 어려웠다. 
