### PR TITLE
[#74][FEATURE] 관리자 - 관리자 페이지 로그인 여부로 접근 제한 기능 추가 

### DIFF
--- a/src/components/adminMode/WithAuth.tsx
+++ b/src/components/adminMode/WithAuth.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface WrappedPropsType {
+	setIsDarkMode?: () => Element;
+	isDarkmode?: boolean;
+}
+
+export default function withAuth<P extends WrappedPropsType>(Component: React.ComponentType<P>) {
+	return function WithAuthComponent({ ...props }) {
+		const navigate = useNavigate();
+		useEffect(() => {
+			const isAdminMode = localStorage.getItem('mode') === 'admin';
+			if (!isAdminMode) navigate('/');
+		}, [navigate]);
+		return <Component {...(props as P)} />;
+	};
+}

--- a/src/pages/Thumbnail.tsx
+++ b/src/pages/Thumbnail.tsx
@@ -1,8 +1,17 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 function Thumbnail() {
 	const navigate = useNavigate();
+
+	useEffect(() => {
+		const mode = localStorage.getItem('mode');
+		if (mode) {
+			localStorage.removeItem('mode');
+		}
+	}, []);
+
 	return (
 		<ThumbnailWrapper>
 			<AdminIcon>

--- a/src/pages/admin/AdminMenu.tsx
+++ b/src/pages/admin/AdminMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
+import withAuth from '../../components/adminMode/WithAuth';
 
 function AdminMenu() {
 	const navigate = useNavigate();
@@ -22,7 +23,7 @@ function AdminMenu() {
 	);
 }
 
-export default AdminMenu;
+export default withAuth(AdminMenu);
 
 const AdminMenuWrapper = styled.div`
 	width: 1194px;

--- a/src/pages/admin/MenuManagement.tsx
+++ b/src/pages/admin/MenuManagement.tsx
@@ -9,6 +9,7 @@ import { useRecoilState, useSetRecoilState } from 'recoil';
 import { categoryListState, selectedCategoryState } from '../../state/CategoryList';
 import { CategoryType, MenuType } from '../../types/menuMangementType';
 import { menuListState } from '../../state/MenuListState';
+import withAuth from '../../components/adminMode/WithAuth';
 
 function MenuManagement() {
 	const setSelectedCategory = useSetRecoilState(selectedCategoryState);
@@ -68,7 +69,7 @@ function MenuManagement() {
 	);
 }
 
-export default MenuManagement;
+export default withAuth(MenuManagement);
 
 const MenuManagementWrapper = styled.div`
 	width: 1194px;

--- a/src/pages/admin/OrderHistory.tsx
+++ b/src/pages/admin/OrderHistory.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import Header from '../../components/OrderHistory/Header';
 import OrderListContainer from '../../components/OrderHistory/OrderListContainer';
+import withAuth from '../../components/adminMode/WithAuth';
 
 function OrderHistory() {
 	const [isProgressMode, setIsProgressMode] = useState<boolean>(true);
@@ -22,7 +23,7 @@ function OrderHistory() {
 	);
 }
 
-export default OrderHistory;
+export default withAuth(OrderHistory);
 
 const HistoryWrapper = styled.div`
 	width: 1194px;

--- a/src/pages/admin/PointList.tsx
+++ b/src/pages/admin/PointList.tsx
@@ -4,6 +4,7 @@ import { defaultTheme, darkTheme } from '../../style/theme';
 import { useNavigate } from 'react-router-dom';
 import { collection, getDocs } from 'firebase/firestore';
 import { db } from '../../firebase/firebaseConfig';
+import withAuth from '../../components/adminMode/WithAuth';
 
 function underBarPhoneNumber(phoneNumber: string): string {
 	const cleaned = ('' + phoneNumber).replace(/\D/g, ''); // 숫자만 남기기
@@ -151,4 +152,4 @@ const Pagination = styled.div`
 	}
 `;
 
-export default PointList;
+export default withAuth(PointList);

--- a/src/pages/admin/SalesList.tsx
+++ b/src/pages/admin/SalesList.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import withAuth from '../../components/adminMode/WithAuth';
 
 function SalesList() {
 	return (
@@ -8,4 +9,4 @@ function SalesList() {
 	);
 }
 
-export default SalesList;
+export default withAuth(SalesList);

--- a/src/pages/admin/ThemeManagement.tsx
+++ b/src/pages/admin/ThemeManagement.tsx
@@ -4,6 +4,7 @@ import ManagementHeader from '../../components/adminMode/ManagementHeader';
 import { useSetRecoilState } from 'recoil';
 import { selectedColorState } from '../../state/ColorState';
 import { SelectedColorType } from '../../style/theme';
+import withAuth from '../../components/adminMode/WithAuth';
 
 interface ThemeManagementProps {
 	setIsDarkmode: React.Dispatch<React.SetStateAction<boolean>>;
@@ -94,7 +95,7 @@ function ThemeManagement({ setIsDarkmode }: ThemeManagementProps) {
 	);
 }
 
-export default ThemeManagement;
+export default withAuth(ThemeManagement);
 
 const ThemeManagementWrapper = styled.div`
 	width: 1194px;

--- a/src/pages/admin/WaitingManagement.tsx
+++ b/src/pages/admin/WaitingManagement.tsx
@@ -7,6 +7,7 @@ import WaitingTableBox from '../../components/waitingManagement/WaitingTableBox'
 import WaitingModal from '../../components/waitingManagement/WaitingModal';
 import { isWaitingAvailableState } from '../../state/WaitingState';
 import { modalState } from '../../state/ModalState';
+import withAuth from '../../components/adminMode/WithAuth';
 
 type DataStatusProps = {
 	$isWaiting: boolean;
@@ -109,7 +110,7 @@ const WaitingManagement = () => {
 	);
 };
 
-export default WaitingManagement;
+export default withAuth(WaitingManagement);
 
 const WaitingManagementWrapper = styled.div`
 	width: 1194px;


### PR DESCRIPTION
close #74 

## ✨ 구현 기능 명세
- 로컬스토리지 mode의 값이 admin인 경우에만 페이지에 접근 가능하도록 withAuth HOC 추가 
- 관리자와 사용자 모두가 접근할 수 있는 첫 페이지인 Thumbnail (메인) 페이지 접근시 로컬스토리지 mode 삭제

## 🎁 PR Point
관리자 로그인 페이지 제외하고 모든 관리자 페이지 로그인한 경우에만 접근 가능한지 체크 부탁드립니다. 

## 🕰 소요시간
1시간 30분

## 😭 어려웠던 점
HOC 컴포넌트에 타입스크립트를 적용하는 것이 어려웠다. 특히 props가 있는 ThemeMangement 컴포넌트에 맞게 제네릭 타입을 지정하는 것이 어려웠다. 
