### PR TITLE
[#78][REFACTOR] 관리자 - 주문 내역 확인 페이지 버튼 렌더링 수정

### DIFF
--- a/src/components/OrderHistory/OrderList.tsx
+++ b/src/components/OrderHistory/OrderList.tsx
@@ -8,8 +8,9 @@ import { changeDateFormat } from '../../utils/changeDateFormat';
 
 interface OrderListPropType {
 	order: OrderListType;
+	isProgressMode: boolean;
 }
-function OrderList({ order }: OrderListPropType) {
+function OrderList({ order, isProgressMode }: OrderListPropType) {
 	const orderRef = collection(db, 'orderList');
 
 	const timeFormat = (id: number) => {
@@ -56,9 +57,11 @@ function OrderList({ order }: OrderListPropType) {
 						<OrderItem key={`${order.id}${idx}`} idx={idx} itemInfo={item} toggleComplete={handleToggleComplete} />
 					))}
 				</ItemWrapper>
-				<button type="button" onClick={handleComplete}>
-					제조완료
-				</button>
+				{isProgressMode && (
+					<button type="button" onClick={handleComplete}>
+						제조완료
+					</button>
+				)}
 			</OrderListWrapper>
 		</>
 	);

--- a/src/components/OrderHistory/OrderListContainer.tsx
+++ b/src/components/OrderHistory/OrderListContainer.tsx
@@ -62,13 +62,13 @@ function OrderListContainer({ isProgressMode }: ContainerPropType) {
 				{isProgressMode ? (
 					<>
 						{inProgressList.map((item) => (
-							<OrderList key={item.id} order={item} />
+							<OrderList key={item.id} order={item} isProgressMode={isProgressMode} />
 						))}
 					</>
 				) : (
 					<>
 						{completeList.map((item) => (
-							<OrderList key={item.id} order={item} />
+							<OrderList key={item.id} order={item} isProgressMode={isProgressMode} />
 						))}
 					</>
 				)}


### PR DESCRIPTION
close #78 

## ✨ 구현 기능 명세
주문 내역 확인 페이지에서 완료주문 내역 제조완료 버튼 제거 

## 🎁 PR Point
진행중과 완료주문에 따라 제조완료 버튼 유무 체크 

## 🕰 소요시간
10분

## 😭 어려웠던 점
없음
