### PR TITLE
[#80][FEATURE] 관리자 - 로그인 리다이렉트 안내 토스트 메세지

### DIFF
--- a/src/components/adminMode/Toast.tsx
+++ b/src/components/adminMode/Toast.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { styled } from 'styled-components';
+
+function Toast() {
+	return <ToastWrapper>로그인 후 이용 가능한 서비스입니다.</ToastWrapper>;
+}
+
+export default Toast;
+
+const ToastWrapper = styled.div`
+	width: 340px;
+	height: 50px;
+	position: fixed;
+	left: 50%;
+	top: 38px;
+	transform: translateX(-170px);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: ${({ theme }) => (theme.lightColor ? theme.lightColor.sub : theme.darkColor.main)};
+	border-radius: 20px;
+	color: ${({ theme }) => theme.textColor.white};
+	font-weight: ${({ theme }) => theme.fontWeight.semibold};
+	font-size: ${({ theme }) => theme.fontSize['lg']};
+`;

--- a/src/components/adminMode/WithAuth.tsx
+++ b/src/components/adminMode/WithAuth.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 interface WrappedPropsType {
 	setIsDarkMode?: () => Element;
@@ -9,10 +9,11 @@ interface WrappedPropsType {
 export default function withAuth<P extends WrappedPropsType>(Component: React.ComponentType<P>) {
 	return function WithAuthComponent({ ...props }) {
 		const navigate = useNavigate();
+		const { pathname } = useLocation();
 		useEffect(() => {
 			const isAdminMode = localStorage.getItem('mode') === 'admin';
-			if (!isAdminMode) navigate('/');
-		}, [navigate]);
+			if (!isAdminMode) navigate('/', { state: pathname.replace('/admin/', '') });
+		}, [navigate, pathname]);
 		return <Component {...(props as P)} />;
 	};
 }

--- a/src/pages/Thumbnail.tsx
+++ b/src/pages/Thumbnail.tsx
@@ -1,38 +1,62 @@
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
+import ModalPortal from '../components/ModalPortal';
+import Toast from '../components/adminMode/Toast';
+
+interface RouteStateType {
+	state: string;
+}
 
 function Thumbnail() {
 	const navigate = useNavigate();
+	const { state } = useLocation() as RouteStateType;
+	const [isShowToast, setIsShowToast] = useState<boolean>(false);
+	const redirectPath: string[] = useMemo(() => {
+		return ['main', 'menu', 'waiting', 'orderhistory', 'sales', 'point', 'theme'];
+	}, []);
 
 	useEffect(() => {
 		const mode = localStorage.getItem('mode');
 		if (mode) {
 			localStorage.removeItem('mode');
 		}
-	}, []);
+		if (redirectPath.includes(state)) {
+			window.history.replaceState({}, '');
+			setIsShowToast(true);
+		}
+		const timer = setTimeout(() => setIsShowToast(false), 3000);
+		return () => clearTimeout(timer);
+	}, [state]);
 
 	return (
-		<ThumbnailWrapper>
-			<AdminIcon>
-				<AdminBtn
-					aria-label="관리자 로그인 페이지로 이동하기"
-					onClick={() => {
-						navigate('/admin/login');
-					}}
-				>
-					<img src={process.env.PUBLIC_URL + '/assets/paw_adminIcon.svg'} alt="관리자 아이콘" />
-				</AdminBtn>
-				<div onClick={() => navigate('/start')}></div>
-			</AdminIcon>
-			<ThumbnailContent onClick={() => navigate('/start')}>
-				<Logo tabIndex={0} onClick={() => navigate('/start')}>
-					<img alt="서비스 로고" />
-				</Logo>
-				<p className="logoText">- 카페에 꼭 필요한 서비스 -</p>
-				<p className="thumbnailText">서비스 이용을 원하시면 화면을 클릭해주세요.</p>
-			</ThumbnailContent>
-		</ThumbnailWrapper>
+		<>
+			<ThumbnailWrapper>
+				<AdminIcon>
+					<AdminBtn
+						aria-label="관리자 로그인 페이지로 이동하기"
+						onClick={() => {
+							navigate('/admin/login');
+						}}
+					>
+						<img src={process.env.PUBLIC_URL + '/assets/paw_adminIcon.svg'} alt="관리자 아이콘" />
+					</AdminBtn>
+					<div onClick={() => navigate('/start')}></div>
+				</AdminIcon>
+				<ThumbnailContent onClick={() => navigate('/start')}>
+					<Logo tabIndex={0} onClick={() => navigate('/start')}>
+						<img alt="서비스 로고" />
+					</Logo>
+					<p className="logoText">- 카페에 꼭 필요한 서비스 -</p>
+					<p className="thumbnailText">서비스 이용을 원하시면 화면을 클릭해주세요.</p>
+				</ThumbnailContent>
+			</ThumbnailWrapper>
+			{isShowToast && (
+				<ModalPortal>
+					<Toast />
+				</ModalPortal>
+			)}
+		</>
 	);
 }
 

--- a/src/pages/admin/AdminLogin.tsx
+++ b/src/pages/admin/AdminLogin.tsx
@@ -73,7 +73,7 @@ const AdminLoginWrapper = styled.div`
 	align-items: center;
 	justify-content: center;
 	width: 1194px;
-	height: 100vh;
+	height: 834px;
 	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : theme.darkColor.background)};
 	img {
 		position: absolute;

--- a/src/pages/admin/AdminLogin.tsx
+++ b/src/pages/admin/AdminLogin.tsx
@@ -3,6 +3,7 @@ import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { db } from '../../firebase/firebaseConfig';
 import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 function AdminLogin() {
 	const navigate = useNavigate();
@@ -36,7 +37,9 @@ function AdminLogin() {
 
 	return (
 		<AdminLoginWrapper>
-			<img alt="카페인 로고" width="100" height="100" />
+			<Link to="/">
+				<img alt="카페인 로고" width="100" height="100" />
+			</Link>
 			<div>
 				<h1>관리자 로그인</h1>
 				<FormWrapper>

--- a/src/pages/admin/MenuManagement.tsx
+++ b/src/pages/admin/MenuManagement.tsx
@@ -73,7 +73,7 @@ export default withAuth(MenuManagement);
 
 const MenuManagementWrapper = styled.div`
 	width: 1194px;
-	height: 100vh;
+	height: 834px;
 	background-color: ${({ theme }) => (theme.lightColor ? '#f9f9f9' : theme.darkColor.background)};
 	overflow-y: auto;
 `;

--- a/src/pages/admin/OrderHistory.tsx
+++ b/src/pages/admin/OrderHistory.tsx
@@ -27,7 +27,7 @@ export default withAuth(OrderHistory);
 
 const HistoryWrapper = styled.div`
 	width: 1194px;
-	height: 100vh;
+	height: 834px;
 	background-color: ${({ theme }) => (theme.lightColor ? '#f9f9f9' : theme.darkColor?.background)};
 	overflow-y: auto;
 `;


### PR DESCRIPTION
close #80 

## ✨ 구현 기능 명세
- 관리자만 접근 권한이 있는 페이지에 로그인하지 않고 접근한 경우 메인 페이지로 리다이렉트할 때 토스트 메세지 띄우기 
- 관리자 로그인 페이지 로고 메인화면 링크 추가 
- 관리자 로그인, 메뉴 관리, 주문 내역 확인 페이지 스타일 높이 수정 

## 🎁 PR Point
적절한 경우에만 토스트 메세지가 나타나는지 체크 부탁드립니다. 
메인 화면으로 이동 후 새로고침시 토스트 메세지가 표시되지 않는지 체크 부탁드립니다. 

## 🕰 소요시간
1시간 

## 😭 어려웠던 점
메인화면으로 이동 후 새로고침 했을 때 WithAuth 컴포넌트에서 전달하는 state 값이 유지되어 새로고침할 때마다 토스트 메세지가 표시되었다.  state 값을 초기화하는 방법으로 해결했다. 
