### PR TITLE
[#75][✨FEATURE] 매출 내역 조회 페이지 마크업 및 스타일링, 기능 구현

### DIFF
--- a/src/pages/admin/SalesList.tsx
+++ b/src/pages/admin/SalesList.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import withAuth from '../../components/adminMode/WithAuth';
 import { styled } from 'styled-components';
 import ManagementHeader from '../../components/adminMode/ManagementHeader';
@@ -10,7 +9,8 @@ function SalesList() {
 			<SalesContent>
 				<DailySalesWrapper>
 					<p>
-						<button>{'<'}</button> 08/13 매출 <button>{'>'}</button>
+						<button aria-label="전 날 매출 보기">{'<'}</button> 08/13 매출{' '}
+						<button aria-label="다음 날 매출 보기">{'>'}</button>
 					</p>
 					<SalesBoxWrapper>
 						<SalesBox className="totalOrder">
@@ -24,7 +24,8 @@ function SalesList() {
 				</DailySalesWrapper>
 				<MonthlySalesWrapper>
 					<p>
-						<button>{'<'}</button> 8월 매출 <button>{'>'}</button>
+						<button aria-label="지난 달 매출 보기">{'<'}</button> 8월 매출{' '}
+						<button aria-label="다음 달 매출 보기">{'>'}</button>
 					</p>
 					<SalesBoxWrapper>
 						<SalesBox>
@@ -66,7 +67,7 @@ const SalesContent = styled.div`
 `;
 
 const SalesBoxWrapper = styled.div`
-	background-color: lavender;
+	background-color: ${({ theme }) => (theme.lightColor ? theme.lightColor.background : theme.darkColor.background)};
 	height: 239px;
 	display: flex;
 	justify-content: center;
@@ -80,7 +81,7 @@ const SalesBoxWrapper = styled.div`
 const SalesBox = styled.div`
 	width: 194px;
 	height: 194px;
-	background-color: white;
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : theme.darkColor.main)};
 	display: flex;
 	flex-flow: column nowrap;
 	align-items: center;

--- a/src/pages/admin/SalesList.tsx
+++ b/src/pages/admin/SalesList.tsx
@@ -161,7 +161,12 @@ function SalesList() {
 					</p>
 					<SalesBoxWrapper>
 						<SalesBox>
-							<p>{targetMonth}월 매출</p> {filterData.length > 0 ? <p>원</p> : <p>0 원</p>}
+							<p>{targetMonth}월 매출</p>{' '}
+							{filterData.length > 0 ? (
+								<p> {filterData.reduce((sum, data) => sum + data.totalPriceSum, 0)}원</p>
+							) : (
+								<p>0 원</p>
+							)}
 						</SalesBox>
 					</SalesBoxWrapper>
 				</MonthlySalesWrapper>

--- a/src/pages/admin/SalesList.tsx
+++ b/src/pages/admin/SalesList.tsx
@@ -1,12 +1,103 @@
 import React from 'react';
 import withAuth from '../../components/adminMode/WithAuth';
+import { styled } from 'styled-components';
+import ManagementHeader from '../../components/adminMode/ManagementHeader';
 
 function SalesList() {
 	return (
-		<div>
-			<h1>매출 내역 조회</h1>
-		</div>
+		<SalesListWrapper>
+			<ManagementHeader headerText="매출 내역 조회" />
+			<SalesContent>
+				<DailySalesWrapper>
+					<p>
+						<button>{'<'}</button> 08/13 매출 <button>{'>'}</button>
+					</p>
+					<SalesBoxWrapper>
+						<SalesBox className="totalOrder">
+							<p>주문 건 수</p>
+							<p>123건</p>
+						</SalesBox>
+						<SalesBox>
+							<p>총 매출 액</p> <p> 12,345원</p>
+						</SalesBox>
+					</SalesBoxWrapper>
+				</DailySalesWrapper>
+				<MonthlySalesWrapper>
+					<p>
+						<button>{'<'}</button> 8월 매출 <button>{'>'}</button>
+					</p>
+					<SalesBoxWrapper>
+						<SalesBox>
+							<p>8월 매출</p> <p>12,345원</p>
+						</SalesBox>
+					</SalesBoxWrapper>
+				</MonthlySalesWrapper>
+			</SalesContent>
+		</SalesListWrapper>
 	);
 }
 
 export default withAuth(SalesList);
+
+const SalesListWrapper = styled.div`
+	width: 1194px;
+	height: 834px;
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : theme.darkColor?.background)};
+	user-select: none;
+	display: flex;
+	flex-flow: column nowrap;
+	align-items: center;
+`;
+
+const SalesContent = styled.div`
+	height: 754px;
+	width: 934px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding-bottom: 100px;
+	p {
+		font-size: ${({ theme }) => theme.fontSize['4xl']};
+		color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : theme.textColor.white)};
+		margin-bottom: 30px;
+		display: flex;
+		justify-content: space-between;
+	}
+`;
+
+const SalesBoxWrapper = styled.div`
+	background-color: lavender;
+	height: 239px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	.totalOrder {
+		margin-right: 46px;
+	}
+`;
+
+const SalesBox = styled.div`
+	width: 194px;
+	height: 194px;
+	background-color: white;
+	display: flex;
+	flex-flow: column nowrap;
+	align-items: center;
+	justify-content: center;
+	line-height: 50px;
+	font-size: ${({ theme }) => theme.fontSize['3xl']};
+	color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : theme.textColor.white)};
+`;
+
+const DailySalesWrapper = styled.div`
+	width: 486px;
+	height: 288px;
+	text-align: center;
+`;
+
+const MonthlySalesWrapper = styled.div`
+	width: 260px;
+	height: 288px;
+	text-align: center;
+`;

--- a/src/pages/admin/SalesList.tsx
+++ b/src/pages/admin/SalesList.tsx
@@ -25,8 +25,28 @@ interface DaySalesData {
 }
 
 function SalesList() {
+	const currentDate = new Date();
+	const targetYear = currentDate.getFullYear();
+	const targetMonth = currentDate.getMonth() + 1;
+
+	const todayDate = currentDate.toISOString().split('T')[0];
 	const [salesList, setSalesList] = useState<Order[]>([]);
 	const [daySalesData, setDaySalesData] = useState<DaySalesData[]>([]);
+	const [displayDate, setDisplayDate] = useState(todayDate);
+
+	const handlePreviousDay = () => {
+		const currentDate = new Date(displayDate);
+		currentDate.setDate(currentDate.getDate() - 1);
+		const previousDate = currentDate.toISOString().split('T')[0];
+		setDisplayDate(previousDate);
+	};
+
+	const handleNextDay = () => {
+		const currentDate = new Date(displayDate);
+		currentDate.setDate(currentDate.getDate() + 1);
+		const nextDate = currentDate.toISOString().split('T')[0];
+		setDisplayDate(nextDate);
+	};
 
 	useEffect(() => {
 		const getSales = async () => {
@@ -42,6 +62,7 @@ function SalesList() {
 		getSales();
 	}, []);
 
+	// 같은 날짜 별로 데이터 그룹화하기
 	useEffect(() => {
 		const salesByDate: { [date: string]: { salesData: Order[]; totalPriceSum: number } } = {};
 
@@ -66,12 +87,8 @@ function SalesList() {
 		setDaySalesData(daySalesList);
 	}, [salesList]);
 
-	const sampleData = daySalesData.filter((v) => v.date === '2023-08-14');
-
-	// 월 별 데이터 가져오기
-	const currentDate = new Date();
-	const targetYear = currentDate.getFullYear();
-	const targetMonth = currentDate.getMonth() + 1;
+	//일 별 데이터 가져오기
+	const dayData = daySalesData.filter((v) => v.date === displayDate);
 
 	const filterData = daySalesData.filter((data) => {
 		const stringDate = data.date.split('-');
@@ -89,18 +106,22 @@ function SalesList() {
 			<SalesContent>
 				<DailySalesWrapper>
 					<p>
-						<button aria-label="전 날 매출 보기">{'<'}</button>
-						{sampleData.length > 0 ? <span> {sampleData[0].date} </span> : <span>로딩중 </span>}
-						<button aria-label="다음 날 매출 보기">{'>'}</button>
+						<button aria-label="전 날 매출 보기" onClick={handlePreviousDay}>
+							{'<'}
+						</button>
+						{dayData.length > 0 ? <span> {dayData[0].date} </span> : <span>{displayDate} </span>}
+						<button aria-label="다음 날 매출 보기" onClick={handleNextDay}>
+							{'>'}
+						</button>
 					</p>
 					<SalesBoxWrapper>
 						<SalesBox className="totalOrder">
 							<p>주문 건 수</p>
-							{sampleData.length > 0 ? <p> {sampleData[0].orderCount}건</p> : <p>0 건</p>}
+							{dayData.length > 0 ? <p> {dayData[0].orderCount}건</p> : <p>0 건</p>}
 						</SalesBox>
 						<SalesBox>
 							<p>총 매출 액</p>
-							{sampleData.length > 0 ? <p> {sampleData[0].totalPriceSum}원</p> : <p>0원</p>}
+							{dayData.length > 0 ? <p> {dayData[0].totalPriceSum}원</p> : <p>0원</p>}
 						</SalesBox>
 					</SalesBoxWrapper>
 				</DailySalesWrapper>

--- a/src/pages/admin/SalesList.tsx
+++ b/src/pages/admin/SalesList.tsx
@@ -1,24 +1,106 @@
+import { useEffect, useState } from 'react';
 import withAuth from '../../components/adminMode/WithAuth';
 import { styled } from 'styled-components';
 import ManagementHeader from '../../components/adminMode/ManagementHeader';
+import { db } from '../../firebase/firebaseConfig';
+import { collection, getDocs } from 'firebase/firestore';
+
+interface Order {
+	id: number;
+	list: {
+		menu: string;
+		quantity: number;
+		options: string;
+		isComplete: boolean;
+	}[];
+	totalPrice: number;
+	takeout: boolean;
+	progress: '진행중' | '완료주문';
+}
+
+interface DaySalesData {
+	date: string;
+	totalPriceSum: number;
+	orderCount: number;
+}
 
 function SalesList() {
+	const [salesList, setSalesList] = useState<Order[]>([]);
+	const [daySalesData, setDaySalesData] = useState<DaySalesData[]>([]);
+
+	useEffect(() => {
+		const getSales = async () => {
+			const orderListCollection = collection(db, 'testOrderList');
+			const salesDocs = await getDocs(orderListCollection);
+			const salesDataList: Order[] = [];
+			salesDocs.forEach((doc) => {
+				salesDataList.push({ ...(doc.data() as Order) });
+			});
+			setSalesList(salesDataList);
+		};
+
+		getSales();
+	}, []);
+
+	useEffect(() => {
+		const salesByDate: { [date: string]: { salesData: Order[]; totalPriceSum: number } } = {};
+
+		salesList.forEach((order) => {
+			const date = new Date(order.id).toISOString().split('T')[0];
+
+			if (!salesByDate[date]) {
+				salesByDate[date] = { salesData: [], totalPriceSum: 0 };
+			}
+
+			salesByDate[date].salesData.push(order);
+			salesByDate[date].totalPriceSum += order.totalPrice;
+		});
+
+		const daySalesList: DaySalesData[] = [];
+
+		for (const date in salesByDate) {
+			const { salesData, totalPriceSum } = salesByDate[date];
+			daySalesList.push({ date, totalPriceSum, orderCount: salesData.length });
+		}
+
+		setDaySalesData(daySalesList);
+	}, [salesList]);
+
+	const sampleData = daySalesData.filter((v) => v.date === '2023-08-14');
+
+	// 월 별 데이터 가져오기
+	const currentDate = new Date();
+	const targetYear = currentDate.getFullYear();
+	const targetMonth = currentDate.getMonth() + 1;
+
+	const filterData = daySalesData.filter((data) => {
+		const stringDate = data.date.split('-');
+		const year = parseInt(stringDate[0]);
+		const month = parseInt(stringDate[1]);
+
+		return year === targetYear && month === targetMonth;
+	});
+
+	// console.log(filterData);
+
 	return (
 		<SalesListWrapper>
 			<ManagementHeader headerText="매출 내역 조회" />
 			<SalesContent>
 				<DailySalesWrapper>
 					<p>
-						<button aria-label="전 날 매출 보기">{'<'}</button> 08/13 매출{' '}
+						<button aria-label="전 날 매출 보기">{'<'}</button>
+						{sampleData.length > 0 ? <span> {sampleData[0].date} </span> : <span>로딩중 </span>}
 						<button aria-label="다음 날 매출 보기">{'>'}</button>
 					</p>
 					<SalesBoxWrapper>
 						<SalesBox className="totalOrder">
 							<p>주문 건 수</p>
-							<p>123건</p>
+							{sampleData.length > 0 ? <p> {sampleData[0].orderCount}건</p> : <p>0 건</p>}
 						</SalesBox>
 						<SalesBox>
-							<p>총 매출 액</p> <p> 12,345원</p>
+							<p>총 매출 액</p>
+							{sampleData.length > 0 ? <p> {sampleData[0].totalPriceSum}원</p> : <p>0원</p>}
 						</SalesBox>
 					</SalesBoxWrapper>
 				</DailySalesWrapper>
@@ -29,7 +111,7 @@ function SalesList() {
 					</p>
 					<SalesBoxWrapper>
 						<SalesBox>
-							<p>8월 매출</p> <p>12,345원</p>
+							<p>8월 매출</p> {filterData.length > 0 ? <p> {filterData.length}건</p> : <p>0 건</p>}
 						</SalesBox>
 					</SalesBoxWrapper>
 				</MonthlySalesWrapper>

--- a/src/pages/admin/SalesList.tsx
+++ b/src/pages/admin/SalesList.tsx
@@ -26,13 +26,39 @@ interface DaySalesData {
 
 function SalesList() {
 	const currentDate = new Date();
-	const targetYear = currentDate.getFullYear();
-	const targetMonth = currentDate.getMonth() + 1;
+	const timezoneOffset = currentDate.getTimezoneOffset(); // 현재 시간대의 UTC 차이 (분 단위)
+	const koreanOffset = 9 * 60; // 한국 시간대의 UTC 차이 (분 단위)
+	const koreanTime = currentDate.getTime() + (koreanOffset - timezoneOffset) * 60 * 1000; // 보정된 시간 (밀리초 단위)
+	const KoreanDate = new Date(koreanTime);
 
-	const todayDate = currentDate.toISOString().split('T')[0];
+	const todayDate = KoreanDate.toISOString().split('T')[0];
 	const [salesList, setSalesList] = useState<Order[]>([]);
 	const [daySalesData, setDaySalesData] = useState<DaySalesData[]>([]);
 	const [displayDate, setDisplayDate] = useState(todayDate);
+	const [targetYear, setTargetYear] = useState(KoreanDate.getFullYear());
+	const [targetMonth, setTargetMonth] = useState(KoreanDate.getMonth() + 1);
+
+	const handleMonthChange = (nextMonth: boolean) => {
+		let newTargetYear = targetYear;
+		let newTargetMonth = targetMonth;
+
+		if (nextMonth) {
+			newTargetMonth += 1;
+			if (newTargetMonth > 12) {
+				newTargetMonth = 1;
+				newTargetYear += 1;
+			}
+		} else {
+			newTargetMonth -= 1;
+			if (newTargetMonth < 1) {
+				newTargetMonth = 12;
+				newTargetYear -= 1;
+			}
+		}
+
+		setTargetYear(newTargetYear);
+		setTargetMonth(newTargetMonth);
+	};
 
 	const handlePreviousDay = () => {
 		const currentDate = new Date(displayDate);
@@ -98,8 +124,6 @@ function SalesList() {
 		return year === targetYear && month === targetMonth;
 	});
 
-	// console.log(filterData);
-
 	return (
 		<SalesListWrapper>
 			<ManagementHeader headerText="매출 내역 조회" />
@@ -127,12 +151,17 @@ function SalesList() {
 				</DailySalesWrapper>
 				<MonthlySalesWrapper>
 					<p>
-						<button aria-label="지난 달 매출 보기">{'<'}</button> 8월 매출{' '}
-						<button aria-label="다음 달 매출 보기">{'>'}</button>
+						<button aria-label="지난 달 매출 보기" onClick={() => handleMonthChange(false)}>
+							{'<'}
+						</button>
+						{targetMonth}월 매출
+						<button aria-label="다음 달 매출 보기" onClick={() => handleMonthChange(true)}>
+							{'>'}
+						</button>
 					</p>
 					<SalesBoxWrapper>
 						<SalesBox>
-							<p>8월 매출</p> {filterData.length > 0 ? <p> {filterData.length}건</p> : <p>0 건</p>}
+							<p>{targetMonth}월 매출</p> {filterData.length > 0 ? <p>원</p> : <p>0 원</p>}
 						</SalesBox>
 					</SalesBoxWrapper>
 				</MonthlySalesWrapper>

--- a/src/pages/admin/SalesList.tsx
+++ b/src/pages/admin/SalesList.tsx
@@ -26,17 +26,12 @@ interface DaySalesData {
 
 function SalesList() {
 	const currentDate = new Date();
-	const timezoneOffset = currentDate.getTimezoneOffset();
-	const koreanOffset = 9 * 60;
-	const koreanTime = currentDate.getTime() + (koreanOffset - timezoneOffset) * 60 * 1000;
-	const KoreanDate = new Date(koreanTime);
-	const todayDate = KoreanDate.toISOString().split('T')[0];
-
+	const todayDate = currentDate.toISOString().split('T')[0];
 	const [salesList, setSalesList] = useState<Order[]>([]);
 	const [daySalesData, setDaySalesData] = useState<DaySalesData[]>([]);
 	const [displayDate, setDisplayDate] = useState(todayDate);
-	const [targetYear, setTargetYear] = useState(KoreanDate.getFullYear());
-	const [targetMonth, setTargetMonth] = useState(KoreanDate.getMonth() + 1);
+	const [targetYear, setTargetYear] = useState(currentDate.getFullYear());
+	const [targetMonth, setTargetMonth] = useState(currentDate.getMonth() + 1);
 
 	useEffect(() => {
 		const getSales = async () => {


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

close #75 
## ✨ 구현 기능 명세
- 매출 내역 조회 페이지 디자인
- 매출 내역 조회 페이지 마크업 및 스타일링
- 웹 접근성 높이기
- 매출 내역 데이터 렌더링
- 특정 날짜, 특정 달의 데이터 렌더링
- 버튼을 통해 날짜, 달 변경

## 🎁 PR Point
버튼 클릭 시 날짜 변경이 잘 되는지, 변경 날짜에 따라 다른 데이터가 렌더링 되는 지

## 🕰 소요시간
약 3시간

## 😭 어려웠던 점
orderList에서 필요한 데이터만 가져와서 특정 날짜, 특정 달에 해당하는 데이터들만 그룹화하는 작업이 생각보다 많이 까다로웠다. 그 그룹화한 데이터를 버튼을 통해 변경되는 날짜에 따라 데이터를 가져오는 기능도 구현하는 데 시간이 꽤 걸렸다. 단순히 렌더링만 하면 되는 페이지일 줄 알았는데 생각보다 까다로운 기능을 요구해서 애를 먹었다. ; ) .. 

<br/>
