### PR TITLE
[#89][REFACTOR] Toast 컴포넌트 재사용 가능하게 수정

### DIFF
--- a/src/components/adminMode/Toast.tsx
+++ b/src/components/adminMode/Toast.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { styled } from 'styled-components';
 
-function Toast() {
-	return <ToastWrapper>로그인 후 이용 가능한 서비스입니다.</ToastWrapper>;
+interface ToastPropTypes {
+	text: string;
+}
+
+function Toast({ text }: ToastPropTypes) {
+	return <ToastWrapper>{text}</ToastWrapper>;
 }
 
 export default Toast;

--- a/src/pages/Thumbnail.tsx
+++ b/src/pages/Thumbnail.tsx
@@ -53,7 +53,7 @@ function Thumbnail() {
 			</ThumbnailWrapper>
 			{isShowToast && (
 				<ModalPortal>
-					<Toast />
+					<Toast text={'로그인 후 이용 가능한 서비스입니다.'} />
 				</ModalPortal>
 			)}
 		</>


### PR DESCRIPTION
close #89 

## ✨ 구현 기능 명세
Toast 컴포넌트의 텍스트를 props로 받는 방식으로 수정하여 재사용성을 높였다. 

## 🎁 PR Point
예외 처리 안내 문구 기능 구현시 사용하면 됩니다. 

## 🕰 소요시간
5분

## 😭 어려웠던 점
없음
