### PR TITLE
[#91][✨ FEATURE & 🔨 REFACTOR]사용자- 메뉴리스트 , 주문확인 내역, 선택아이템 수정

### DIFF
--- a/src/components/UserMode/AddPointModal.tsx
+++ b/src/components/UserMode/AddPointModal.tsx
@@ -75,7 +75,7 @@ function AddPointModal({ onClickToggleModal }: ModalDefaultType) {
 				</BtnContainer>
 			</DialogBox>
 			{isOpenModal &&
-				(theme === defaultTheme ? (
+				(theme.lightColor ? (
 					<PointAddCheckModal
 						onClickOpenModal={onClickOpenModal}
 						isOpenModal={isOpenModal}
@@ -83,7 +83,12 @@ function AddPointModal({ onClickToggleModal }: ModalDefaultType) {
 						isNewUser={isNewUser}
 					/>
 				) : (
-					<Dark_PointAddCheckModal onClickOpenModal={onClickOpenModal} isOpenModal={isOpenModal} />
+					<Dark_PointAddCheckModal
+						onClickOpenModal={onClickOpenModal}
+						isOpenModal={isOpenModal}
+						phoneNumber={phoneNumber}
+						isNewUser={isNewUser}
+					/>
 				))}
 			<Backdrop
 				onClick={(e: React.MouseEvent) => {
@@ -112,7 +117,7 @@ const DialogBox = styled.dialog`
 	justify-content: center;
 	align-items: center;
 	background-color: ${({ theme }) =>
-		theme === defaultTheme ? theme.lightColor?.yellow.background : darkTheme.textColor.black};
+		theme.lightColor ? defaultTheme.lightColor?.yellow.background : darkTheme.textColor.black};
 	border: none;
 	border-radius: 10px;
 	box-shadow: 0 0 30px rgba(30, 30, 30, 0.185);
@@ -157,11 +162,11 @@ export const CloseBtn = styled.button`
 	margin-top: 10px;
 	margin-left: 10px;
 	border-radius: 10px;
-	background-color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.lightgray : darkTheme.darkColor?.sub)};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.lightgray : darkTheme.darkColor?.sub)};
 	width: 110px;
 	height: 35px;
 	font-size: ${({ theme }) => theme.fontSize['xl']};
-	color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.black : darkTheme.textColor.white)};
+	color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : darkTheme.textColor.white)};
 `;
 const BtnContainer = styled.div`
 	display: flex;

--- a/src/components/UserMode/CheckPointUsedIt.tsx
+++ b/src/components/UserMode/CheckPointUsedIt.tsx
@@ -50,7 +50,7 @@ function CheckPointUsedIt({ isOpenModal, onClickOpenModal, points, onUsePoints, 
 					<p>{phoneLastFourDigits.slice(-4)} 님, </p>
 					<p>사용하실 포인트 입력 해주세요 </p>
 					<img
-						src={theme === defaultTheme ? '/assets/user/yellowcloud_light.svg' : '/assets/user/pinkcloud_dark.svg'}
+						src={theme.lightColor ? '/assets/user/yellowcloud_light.svg' : '/assets/user/pinkcloud_dark.svg'}
 						alt=""
 						width={95}
 					/>
@@ -94,7 +94,7 @@ const DialogBox = styled.dialog`
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	background-color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.white : darkTheme.textColor.black)};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : darkTheme.textColor.black)};
 	border: none;
 	border-radius: 10px;
 	box-sizing: border-box;
@@ -104,7 +104,7 @@ const DialogBox = styled.dialog`
 		text-align: center;
 		font-weight: ${({ theme }) => theme.fontWeight.bold};
 		font-size: ${({ theme }) => theme.fontSize['3xl']};
-		color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.black : darkTheme.textColor.white)};
+		color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : darkTheme.textColor.white)};
 		p {
 			padding-top: 10px;
 		}
@@ -128,7 +128,7 @@ const DialogBox = styled.dialog`
 			border-radius: 10px;
 		}
 		p {
-			color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.black : darkTheme.textColor.lightgray)};
+			color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : darkTheme.textColor.lightgray)};
 		}
 	}
 `;

--- a/src/components/UserMode/CheckPointUsedIt.tsx
+++ b/src/components/UserMode/CheckPointUsedIt.tsx
@@ -40,6 +40,7 @@ function CheckPointUsedIt({ isOpenModal, onClickOpenModal, points, onUsePoints, 
 	};
 	const handlePointClick = () => {
 		setPoint(points?.toString() ?? '');
+		setUsedPoints(points);
 	};
 	const phoneLastFourDigits = phoneNumber.slice(-4);
 	return isOpenModal ? (

--- a/src/components/UserMode/MenuItem.tsx
+++ b/src/components/UserMode/MenuItem.tsx
@@ -8,12 +8,13 @@ import { db } from '../../firebase/firebaseConfig';
 import { selectedCategoryState } from '../../state/CategoryList';
 import { selectedItemsState } from '../../firebase/FirStoreDoc';
 import { Option, selectedItem } from '../../types/OptinalState';
+import { takeOutState } from '../../state/TakeOut';
 function MenuItem() {
 	const selectedCategory = useRecoilValue(selectedCategoryState);
 	const [isOpenModal, setModalOpen] = useState<boolean>(false);
 	const [items, setItems] = useState<Item[]>([]);
 	const [selectedItems, setSelectedItems] = useRecoilState(selectedItemsState);
-
+	const takeOut = useRecoilValue(takeOutState);
 	const [clickedMenuItem, setClickedMenuItem] = useState<Item | null>(null);
 	const onClickToggleModal = useCallback(() => {
 		setModalOpen(!isOpenModal);
@@ -34,6 +35,7 @@ function MenuItem() {
 					const data = doc.data() as Item;
 					return {
 						...data,
+						takeOut,
 						price: Number(data.price),
 					} as Item;
 				});

--- a/src/components/UserMode/MenuItem.tsx
+++ b/src/components/UserMode/MenuItem.tsx
@@ -14,8 +14,7 @@ function MenuItem() {
 	const [items, setItems] = useState<Item[]>([]);
 	const [selectedItems, setSelectedItems] = useRecoilState(selectedItemsState);
 
-	const [clickedMenuItem, setClickedMenuItem] = useState<Item | null>(null); // 추가: 클릭한 메뉴 아이템 저장용 상태
-
+	const [clickedMenuItem, setClickedMenuItem] = useState<Item | null>(null);
 	const onClickToggleModal = useCallback(() => {
 		setModalOpen(!isOpenModal);
 	}, [isOpenModal]);

--- a/src/components/UserMode/MenuListHeader.tsx
+++ b/src/components/UserMode/MenuListHeader.tsx
@@ -4,9 +4,10 @@ import { useNavigate } from 'react-router-dom';
 import { darkTheme, defaultTheme } from '../../style/theme';
 import { Category } from '../../types/Category';
 import { db } from '../../firebase/firebaseConfig';
-import { getDocs, collection } from 'firebase/firestore';
+import { getDocs, collection, query, orderBy } from 'firebase/firestore';
 import { useSetRecoilState } from 'recoil';
 import { selectedCategoryState } from '../../state/CategoryList';
+import { DocumentData } from 'firebase/firestore';
 
 function MenuListHeader() {
 	const setCategory = useSetRecoilState(selectedCategoryState);
@@ -16,12 +17,19 @@ function MenuListHeader() {
 	const theme = useTheme();
 	useEffect(() => {
 		const loadCategories = async () => {
-			const querySnapshot = await getDocs(collection(db, 'categoryList'));
+			const categoryQuery = query(collection(db, 'categoryList'), orderBy('id', 'asc'));
+			const querySnapshot = await getDocs(categoryQuery);
 			const loadedCategories = querySnapshot.docs.map((doc) => ({
 				id: doc.id,
 				category: doc.data().category,
 			}));
+
 			setCategories(loadedCategories);
+
+			// 첫 번째 카테고리 (커피)를 기본으로 설정
+			if (loadedCategories.length > 0) {
+				setCategory(loadedCategories[0].category);
+			}
 		};
 		loadCategories();
 	}, []);
@@ -60,7 +68,7 @@ function MenuListHeader() {
 //prettier-ignore
 const TabButton = styled.button<{ $isActive: boolean }>`
 background-color: ${({ $isActive }) => ($isActive ? 'ghostwhite' : 'transparent')};
-	color: ${({ $isActive }) => ($isActive ? 'darkorange' : 'black')}; 
+	 color: ${({ $isActive }) => ($isActive ? 'red' : 'black')}; 
 	font-size: ${({ theme }) => theme.fontSize['2xl']};
 	font-weight: ${({ theme }) => theme.fontWeight.semibold};
 	padding: 10px 30px;

--- a/src/components/UserMode/MenuListHeader.tsx
+++ b/src/components/UserMode/MenuListHeader.tsx
@@ -48,7 +48,7 @@ function MenuListHeader() {
 		<Layout>
 			<li>
 				<h1 onClick={handleLogoClick}>
-					<img src={theme === defaultTheme ? '/assets/logo.png' : '/assets/logo_dark.png'} alt="cafe-in" width={90} />
+					<img src={theme.lightColor ? '/assets/logo.png' : '/assets/logo_dark.png'} alt="cafe-in" width={90} />
 				</h1>
 			</li>
 			{categories.map((category) => (
@@ -88,8 +88,7 @@ const Layout = styled.ul`
 	height: 83px;
 	padding: 0 30px;
 	border-bottom: 1px solid ${({ theme }) => theme.textColor.lightgray};
-	background-color: ${({ theme }) =>
-		theme === defaultTheme ? defaultTheme.textColor.white : darkTheme.darkColor.background};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : theme.darkColor.background)};
 `;
 
 export default MenuListHeader;

--- a/src/components/UserMode/MenuListHeader.tsx
+++ b/src/components/UserMode/MenuListHeader.tsx
@@ -11,7 +11,7 @@ import { DocumentData } from 'firebase/firestore';
 
 function MenuListHeader() {
 	const setCategory = useSetRecoilState(selectedCategoryState);
-	const [activeBtn] = useState<string>('');
+	const [activeBtn, setActiveBtn] = useState<string>('');
 	const [categories, setCategories] = useState<Category[]>([]);
 	const navigate = useNavigate();
 	const theme = useTheme();
@@ -28,12 +28,14 @@ function MenuListHeader() {
 
 			// 첫 번째 카테고리 (커피)를 기본으로 설정
 			if (loadedCategories.length > 0) {
+				setActiveBtn(loadedCategories[0].category); // 첫 번째 카테고리로 activeBtn 설정
 				setCategory(loadedCategories[0].category);
 			}
 		};
 		loadCategories();
 	}, []);
 	const onCategoryClick = (category: string) => {
+		setActiveBtn(category); // activeBtn 상태 업데이트
 		setCategory(category);
 	};
 	const setSelectedCategory = useSetRecoilState(selectedCategoryState);
@@ -41,6 +43,7 @@ function MenuListHeader() {
 	const handleLogoClick = () => {
 		setSelectedCategory(''); // 또는 null 등 초기화
 	};
+
 	return (
 		<Layout>
 			<li>
@@ -68,7 +71,7 @@ function MenuListHeader() {
 //prettier-ignore
 const TabButton = styled.button<{ $isActive: boolean }>`
 background-color: ${({ $isActive }) => ($isActive ? 'ghostwhite' : 'transparent')};
-	 color: ${({ $isActive }) => ($isActive ? 'red' : 'black')}; 
+	color: ${({ $isActive }) => ($isActive ? 'red' : 'black')}; 
 	font-size: ${({ theme }) => theme.fontSize['2xl']};
 	font-weight: ${({ theme }) => theme.fontWeight.semibold};
 	padding: 10px 30px;

--- a/src/components/UserMode/OptionMenu.tsx
+++ b/src/components/UserMode/OptionMenu.tsx
@@ -6,7 +6,8 @@ import { collection, getDocs } from 'firebase/firestore';
 import { Item } from '../../types/Category';
 import { darkTheme, defaultTheme } from '../../style/theme';
 import { selectedItemsState } from '../../firebase/FirStoreDoc';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { takeOutState } from '../../state/TakeOut';
 export interface OptionMenuProps {
 	clickedItem: Item | null;
 	onClickToggleModal: () => void;
@@ -17,7 +18,7 @@ function OptionMenu({ clickedItem, onClickToggleModal }: OptionMenuProps) {
 	const [activeOptions, setActiveOptions] = useState<string[]>([]);
 	const [selectedItems, setSelectedItems] = useRecoilState(selectedItemsState);
 	const [selectedItemOptions, setSelectedItemOptions] = useState<Option[]>([]);
-
+	const takeOut = useRecoilValue(takeOutState);
 	useEffect(() => {
 		const fetchOptions = async () => {
 			const optionsCollection = collection(db, 'options');
@@ -61,6 +62,7 @@ function OptionMenu({ clickedItem, onClickToggleModal }: OptionMenuProps) {
 		const newItem = {
 			...clickedItem!,
 			options: optionsStr,
+			takeOut: takeOut,
 			totalPrice: (clickedItem?.price || 0) + additionalPrice,
 			quantity: 1,
 			imageUrl: clickedItem?.imageUrl,

--- a/src/components/UserMode/OptionMenu.tsx
+++ b/src/components/UserMode/OptionMenu.tsx
@@ -194,7 +194,7 @@ const CheckOption = styled.button`
 const CloseBtn = styled.button`
 	margin-top: 20px;
 	border-radius: 10px;
-	background-color: ${({ theme }) => (theme === defaultTheme ? theme.lightColor.sub : darkTheme.darkColor.sub)};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.lightColor.sub : darkTheme.darkColor.sub)};
 	width: 110px;
 	height: 45px;
 	font-size: ${({ theme }) => theme.fontSize['2xl']};

--- a/src/components/UserMode/OptionMenu.tsx
+++ b/src/components/UserMode/OptionMenu.tsx
@@ -63,6 +63,7 @@ function OptionMenu({ clickedItem, onClickToggleModal }: OptionMenuProps) {
 			options: optionsStr,
 			totalPrice: (clickedItem?.price || 0) + additionalPrice,
 			quantity: 1,
+			imageUrl: clickedItem?.imageUrl,
 		};
 
 		setSelectedItems((prev) => {

--- a/src/components/UserMode/PointAddCheckModal.tsx
+++ b/src/components/UserMode/PointAddCheckModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { styled } from 'styled-components';
 import { ModalAndModalType } from '../../types/ModalOpenTypes';
+import { defaultTheme } from '../../style/theme';
 interface PointAddCheckModalProps extends ModalAndModalType {
 	isOpenModal: boolean;
 	phoneNumber: string;
@@ -43,7 +44,7 @@ const DialogBox = styled.dialog`
 	box-sizing: border-box;
 	z-index: 10000;
 	.ment {
-		background-color: ${({ theme }) => theme.lightColor?.yellow.background};
+		background-color: ${defaultTheme.lightColor.yellow.background};
 		width: 450px;
 		display: flex;
 		flex-direction: column;

--- a/src/components/UserMode/SelectedItemContainer.tsx
+++ b/src/components/UserMode/SelectedItemContainer.tsx
@@ -57,6 +57,7 @@ function SelectedItemContainer() {
 			takeOut: true,
 			list: selectedItems.map((item) => ({
 				menu: item.name,
+				imgUrl: item.imageUrl || '/assets/user/IceCoffee.svg',
 				quantity: item.quantity,
 				options: item.options,
 				isComplete: false,

--- a/src/components/UserMode/SelectedItemContainer.tsx
+++ b/src/components/UserMode/SelectedItemContainer.tsx
@@ -152,7 +152,7 @@ function SelectedItemContainer() {
 }
 const Background = styled.div`
 	background-color: ${({ theme }) =>
-		theme === defaultTheme ? defaultTheme.textColor.white : darkTheme.darkColor.background};
+		theme.lightColor ? defaultTheme.textColor.white : darkTheme.darkColor.background};
 	padding: 10px;
 	height: fit-content;
 `;
@@ -168,7 +168,7 @@ const MenuSelectedContainer = styled.ul`
 	flex-direction: column;
 	height: 440px;
 	background-color: ${({ theme }) =>
-		theme === defaultTheme ? defaultTheme.lightColor?.yellow.background : darkTheme.darkColor.background};
+		theme.lightColor ? defaultTheme.lightColor?.yellow.background : darkTheme.darkColor.background};
 	border-radius: 10px;
 	overflow-y: auto;
 
@@ -219,16 +219,17 @@ const SelectedItem = styled.li<StyledProps>`
 		}
 		.plus {
 			background-color: ${({ theme }) =>
-				theme === defaultTheme ? defaultTheme.lightColor?.yellow.main : darkTheme.darkColor?.main};
+				theme.lightColor ? defaultTheme.lightColor?.yellow.main : darkTheme.darkColor?.main};
 		}
 		.minus {
-			background-color: ${({ theme, $quantity }) => {
-				if (theme === defaultTheme) {
-					return $quantity > 1 ? theme.lightColor?.yellow.main : defaultTheme.textColor.lightgray;
-				} else {
-					return $quantity > 1 ? darkTheme.darkColor?.main : darkTheme.textColor.darkgray;
-				}
-			}};
+			background-color: ${({ theme, $quantity }) =>
+				theme.lightColor
+					? $quantity > 1
+						? defaultTheme.lightColor?.yellow.main
+						: defaultTheme.textColor.lightgray
+					: $quantity > 1
+					? darkTheme.darkColor?.main
+					: darkTheme.textColor.darkgray};
 			&:disabled {
 				pointer-events: none;
 			}
@@ -243,9 +244,8 @@ const SelectedItem = styled.li<StyledProps>`
 			width: 25px;
 			height: 25px;
 			border: 2px solid
-				${({ theme }) => (theme === defaultTheme ? defaultTheme.lightColor?.yellow.sub : darkTheme.darkColor?.point)};
-			color: ${({ theme }) =>
-				theme === defaultTheme ? defaultTheme.lightColor?.yellow.sub : darkTheme.darkColor?.point};
+				${({ theme }) => (theme.lightColor ? defaultTheme.lightColor?.yellow.sub : darkTheme.darkColor?.point)};
+			color: ${({ theme }) => (theme.lightColor ? defaultTheme.lightColor?.yellow.sub : darkTheme.darkColor?.point)};
 			border-radius: 5px;
 		}
 	}
@@ -276,19 +276,17 @@ const TotalPrice = styled.div`
 	height: 110px;
 	padding: 20px 10px 10px 10px;
 	color: ${defaultTheme.lightColor.yellow.point};
-	background-color: ${({ theme }) =>
-		theme === defaultTheme ? theme.textColor.lightbrown : darkTheme.darkColor.background};
-	border-top: ${({ theme }) => (theme === darkTheme ? '1px solid  darkTheme.textColor.lightgray' : 'none')};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.lightbrown : darkTheme.darkColor.background)};
+	border-top: ${({ theme }) => (theme.lightColor ? '1px solid  darkTheme.textColor.lightgray' : 'none')};
 	font-size: ${({ theme }) => theme.fontSize['2xl']};
 	font-weight: ${({ theme }) => theme.fontWeight.bold};
 	& p:first-child {
-		color: ${({ theme }) =>
-			theme === darkTheme ? defaultTheme.lightColor.yellow.point : darkTheme.textColor.lightbrown};
+		color: ${({ theme }) => (theme.lightColor ? defaultTheme.lightColor.yellow.point : darkTheme.textColor.lightbrown)};
 	}
 	.total-price {
 		float: right;
 		font-size: ${({ theme }) => theme.fontSize['4xl']};
-		color: ${({ theme }) => (theme === darkTheme ? theme.textColor.black : darkTheme.textColor.white)};
+		color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : darkTheme.textColor.white)};
 		right: 15px;
 		bottom: 500px;
 	}
@@ -320,6 +318,6 @@ const OrderBtn = styled.button`
 	font-weight: ${({ theme }) => theme.fontWeight.semibold};
 	color: ${({ theme }) => theme.textColor.black};
 	background-color: ${({ theme }) =>
-		theme === defaultTheme ? theme.lightColor?.yellow.sub : darkTheme.darkColor?.point};
+		theme.lightColor ? defaultTheme.lightColor?.yellow.sub : darkTheme.darkColor?.point};
 `;
 export default SelectedItemContainer;

--- a/src/components/UserMode/SelectedItemContainer.tsx
+++ b/src/components/UserMode/SelectedItemContainer.tsx
@@ -66,6 +66,8 @@ function SelectedItemContainer() {
 		};
 
 		setOrderList((prev) => [...prev, newOrder]);
+		// 선택된 항목 초기화
+		handleDeleteAll();
 	};
 	useEffect(() => {
 		let lastInteraction = Date.now();

--- a/src/components/UserMode/SelectedItemContainer.tsx
+++ b/src/components/UserMode/SelectedItemContainer.tsx
@@ -3,17 +3,18 @@ import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import { defaultTheme, darkTheme } from '../../style/theme';
 
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { selectedItemsState } from '../../firebase/FirStoreDoc';
 import { orderListStateAtom } from '../../state/OrderListAtom';
 import { OrderProgress } from '../../types/Order';
+import { takeOutState } from '../../state/TakeOut';
 type StyledProps = {
 	$quantity: number;
 };
 
 function SelectedItemContainer() {
 	const navigate = useNavigate();
-
+	const takeOut = useRecoilValue(takeOutState);
 	const [selectedItems, setSelectedItems] = useRecoilState(selectedItemsState);
 	const [orderList, setOrderList] = useRecoilState(orderListStateAtom);
 	const handleItemDelete = (itemName: string) => {
@@ -54,7 +55,7 @@ function SelectedItemContainer() {
 			id: Date.now(),
 			date: Date(),
 			progress: '주문완료' as OrderProgress,
-			takeOut: true,
+			takeOut: takeOut,
 			list: selectedItems.map((item) => ({
 				menu: item.name,
 				imgUrl: item.imageUrl || '/assets/user/IceCoffee.svg',

--- a/src/components/UserMode/SelectedItemContainer.tsx
+++ b/src/components/UserMode/SelectedItemContainer.tsx
@@ -138,7 +138,7 @@ function SelectedItemContainer() {
 						<img src="/assets/user/AllDeleteBtn.svg" alt="전체삭제" />
 						<p>전체삭제</p>
 					</AllDeleteBtn>
-					<OrderBtn onClick={handleAddOrderMoveTo}>
+					<OrderBtn disabled={selectedItems.length === 0} onClick={handleAddOrderMoveTo}>
 						<p>주문하기</p>
 					</OrderBtn>
 				</PayContainer>

--- a/src/components/UserMode/SelectedItemContainer.tsx
+++ b/src/components/UserMode/SelectedItemContainer.tsx
@@ -53,7 +53,7 @@ function SelectedItemContainer() {
 		const newOrder = {
 			id: Date.now(),
 			date: Date(),
-			progress: '진행중' as OrderProgress,
+			progress: '주문완료' as OrderProgress,
 			takeOut: true,
 			list: selectedItems.map((item) => ({
 				menu: item.name,

--- a/src/components/UserMode/UsePointUser.tsx
+++ b/src/components/UserMode/UsePointUser.tsx
@@ -33,6 +33,11 @@ function UsePointUser({ onClickToggleModal }: ModalDefaultType) {
 				onClickToggleModal();
 				return;
 			}
+			if (points < 1000) {
+				alert(`1000포인트 이상 사용할 수 있습니다. 현재 ${points} 포인트 입니다.`);
+				onClickToggleModal();
+				return;
+			}
 			setUserPoints(points);
 			setModalOpen(true);
 		} else {
@@ -43,20 +48,23 @@ function UsePointUser({ onClickToggleModal }: ModalDefaultType) {
 	}, [phoneNumber]);
 
 	const handleUsePoints = async (usedPoints: number) => {
-		if (userPoints !== null && userPoints >= usedPoints) {
-			const remainingPoints = userPoints - usedPoints;
-			setUserPoints(remainingPoints);
-
-			const pointsCollection = collection(db, 'point');
-			const q = query(pointsCollection, where('phoneNumber', '==', phoneNumber));
-			const matchingDocs = await getDocs(q);
-			if (!matchingDocs.empty) {
-				const existingDoc = matchingDocs.docs[0];
-				const docRef = doc(db, 'point', existingDoc.id);
-				await updateDoc(docRef, { point: remainingPoints });
-			}
-		} else {
+		if (userPoints === null || userPoints < usedPoints) {
 			alert('포인트가 부족합니다.');
+			return;
+		}
+
+		const remainingPoints = userPoints - usedPoints;
+
+		setUserPoints(remainingPoints);
+
+		const pointsCollection = collection(db, 'point');
+		const q = query(pointsCollection, where('phoneNumber', '==', phoneNumber));
+		const matchingDocs = await getDocs(q);
+
+		if (!matchingDocs.empty) {
+			const existingDoc = matchingDocs.docs[0];
+			const docRef = doc(db, 'point', existingDoc.id);
+			await updateDoc(docRef, { point: remainingPoints });
 		}
 	};
 	return (

--- a/src/components/UserMode/UsePointUser.tsx
+++ b/src/components/UserMode/UsePointUser.tsx
@@ -124,7 +124,7 @@ const DialogBox = styled.dialog`
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	background-color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.white : darkTheme.textColor.black)};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : darkTheme.textColor.black)};
 	border: none;
 	border-radius: 10px;
 	box-shadow: 0 0 30px rgba(30, 30, 30, 0.185);
@@ -133,7 +133,7 @@ const DialogBox = styled.dialog`
 	p {
 		font-size: ${({ theme }) => theme.fontSize.xl};
 		font-weight: ${({ theme }) => theme.fontWeight.semibold};
-		color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.black : darkTheme.textColor.white)};
+		color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : darkTheme.textColor.white)};
 	}
 `;
 
@@ -141,9 +141,8 @@ const PointInput = styled.div`
 	font-size: ${({ theme }) => theme.fontSize.base};
 	margin-top: 50px;
 	input {
-		background-color: ${({ theme }) =>
-			theme === defaultTheme ? theme.textColor.lightgray : darkTheme.textColor.white};
-		border: 1px solid ${({ theme }) => (theme === defaultTheme ? theme.textColor.lightbrown : 'none')};
+		background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.lightgray : darkTheme.textColor.white)};
+		border: 1px solid ${({ theme }) => (theme.lightColor ? theme.textColor.lightbrown : 'none')};
 		position: relative;
 		width: 390px;
 		padding: 20px;
@@ -154,8 +153,7 @@ const PointInput = styled.div`
 		margin-top: 6px;
 		padding: 7px;
 		right: 60px;
-		background-color: ${({ theme }) =>
-			theme === defaultTheme ? theme.textColor.lightgray : darkTheme.textColor.white};
+		background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.lightgray : darkTheme.textColor.white)};
 		border-radius: 10px;
 	}
 	input:focus {
@@ -172,11 +170,11 @@ const CloseBtn = styled.button`
 	margin-top: 50px;
 	margin-left: 20px;
 	border-radius: 10px;
-	background-color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.lightgray : darkTheme.darkColor?.sub)};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.lightgray : darkTheme.darkColor?.sub)};
 	width: 110px;
 	height: 35px;
 	font-size: ${({ theme }) => theme.fontSize.xl};
-	color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.black : darkTheme.textColor.white)};
+	color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : darkTheme.textColor.white)};
 `;
 const BtnContainer = styled.div`
 	display: flex;

--- a/src/components/adminMode/Toast.tsx
+++ b/src/components/adminMode/Toast.tsx
@@ -14,7 +14,7 @@ export default Toast;
 const ToastWrapper = styled.div`
 	width: 340px;
 	height: 50px;
-	position: fixed;
+	position: absolute;
 	left: 50%;
 	top: 38px;
 	transform: translateX(-170px);

--- a/src/components/darkThemeModal/Dark_PointAddCheckModal.tsx
+++ b/src/components/darkThemeModal/Dark_PointAddCheckModal.tsx
@@ -5,14 +5,18 @@ import { darkTheme, defaultTheme } from '../../style/theme';
 interface Dark_PointAddCheckModal extends ModalAndModalType {
 	onClickOpenModal: () => void;
 	isOpenModal: boolean;
+	phoneNumber: string;
+	isNewUser: boolean | null;
 }
 
-function Dark_PointAddCheckModal({ isOpenModal, onClickOpenModal }: Dark_PointAddCheckModal) {
+function Dark_PointAddCheckModal({ isOpenModal, onClickOpenModal, phoneNumber, isNewUser }: Dark_PointAddCheckModal) {
 	return isOpenModal ? (
 		<ModalContainer onClick={onClickOpenModal}>
 			<DialogBox onClick={(e) => e.stopPropagation()}>
 				<div className="ment">
-					<p> 0 0 0 0 님, 환영합니다 !</p>
+					<p>
+						{phoneNumber.slice(-4)} 님,{isNewUser ? '환영합니다 !' : '적립되었습니다!'}
+					</p>
 					<p>포인트를 적립하여 혜택을 받아보세요 ! </p>
 				</div>
 				<img className="pink-girl" src="/assets/user/pink_girl_dark.svg" alt="로켓" width={550} />

--- a/src/pages/user/MenuList.tsx
+++ b/src/pages/user/MenuList.tsx
@@ -36,7 +36,7 @@ const MenuListLayout = styled.ul`
 	display: grid;
 	grid-template-columns: 1fr 1fr 1fr;
 	gap: 8px;
-	height: 830px;
+	height: 700px;
 	margin: 30px 0;
 	overflow-y: auto;
 	overflow-x: hidden;

--- a/src/pages/user/MenuList.tsx
+++ b/src/pages/user/MenuList.tsx
@@ -20,8 +20,7 @@ function MenuList() {
 }
 
 const Layout = styled.div`
-	background-color: ${({ theme }) =>
-		theme === defaultTheme ? defaultTheme.textColor.lightgray : darkTheme.darkColor.background};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.lightgray : theme.darkColor.background)};
 	width: 1194px;
 	height: 834px;
 	overflow-y: hidden;

--- a/src/pages/user/OrderCheck.tsx
+++ b/src/pages/user/OrderCheck.tsx
@@ -66,7 +66,7 @@ function OrderCheck() {
 				>
 					<img
 						className="backBtn"
-						src={theme === defaultTheme ? '/assets/user/BackBtn_light.svg' : '/assets/user/BackBtn_dark.svg'}
+						src={theme.lightColor ? '/assets/user/BackBtn_light.svg' : '/assets/user/BackBtn_dark.svg'}
 						alt="메뉴페이지"
 					/>
 				</BackBTn>
@@ -139,14 +139,14 @@ const Layout = styled.div`
 	width: 1194px;
 	height: 100%;
 	position: relative;
-	background-color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.white : darkTheme.darkColor.background)};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.white : darkTheme.darkColor.background)};
 	overflow-y: hidden;
 `;
 const Header = styled.div`
 	display: flex;
 	border-bottom: 1px solid ${({ theme }) => theme.textColor.lightgray};
 	padding: 10px;
-	color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.black : darkTheme.textColor.white)};
+	color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : darkTheme.textColor.white)};
 
 	h1 {
 		width: 100%;
@@ -172,14 +172,13 @@ const TableHead = styled.ul`
 	width: 100%;
 	height: 69px;
 	border-radius: 10px;
-	background-color: ${({ theme }) =>
-		theme === defaultTheme ? theme.textColor.lightgray : darkTheme.textColor.lightbrown};
+	background-color: ${({ theme }) => (theme.lightColor ? theme.textColor.lightgray : darkTheme.textColor.lightbrown)};
 	font-weight: ${({ theme }) => theme.fontWeight.semibold};
 	font-size: ${({ theme }) => theme.fontSize.xl};
 `;
 const Tbody = styled.ul`
-	background-color: ${({ theme }) => (theme === defaultTheme ? theme.lightColor?.yellow.background : 'none')};
-	border: ${({ theme }) => (theme === darkTheme ? 'none' : `1px solid ${darkTheme.textColor.white}`)};
+	background-color: ${({ theme }) => (theme.lightColor ? defaultTheme.lightColor?.yellow.background : 'none')};
+	border: ${({ theme }) => (theme.lightColor ? 'none' : `1px solid ${darkTheme.textColor.white}`)};
 	border-radius: 10px;
 	height: 650px;
 	display: flex;
@@ -198,7 +197,8 @@ const Tbody = styled.ul`
 const OrderMenuItem = styled.li`
 	display: flex;
 	align-items: center;
-	background-color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.white : darkTheme.textColor.lightbrown)};
+	background-color: ${({ theme }) =>
+		theme.lightColor ? defaultTheme.textColor.white : darkTheme.textColor.lightbrown};
 	margin: 10px 25px;
 	padding: 10px;
 	border-radius: 10px;
@@ -233,7 +233,7 @@ const BackBTn = styled.button`
 const OrderTotalPriceContainer = styled.div`
 	flex-grow: 1;
 	height: 100%;
-	color: ${({ theme }) => (theme === defaultTheme ? theme.textColor.black : darkTheme.textColor.white)};
+	color: ${({ theme }) => (theme.lightColor ? theme.textColor.black : darkTheme.textColor.white)};
 `;
 const TotalPrice = styled.div`
 	display: flex;
@@ -263,7 +263,7 @@ const Payment = styled.div`
 		align-items: center;
 		width: 230px;
 		background-color: ${({ theme }) =>
-			theme === defaultTheme ? theme.lightColor?.blue.background : darkTheme.darkColor?.sub};
+			theme.lightColor ? defaultTheme.lightColor?.blue.background : darkTheme.darkColor?.sub};
 		height: 120px;
 		border-radius: 10px;
 		margin-bottom: 40px;
@@ -276,7 +276,7 @@ const Payment = styled.div`
 		align-items: center;
 		width: 230px;
 		background-color: ${({ theme }) =>
-			theme === defaultTheme ? theme.lightColor?.blue.background : darkTheme.darkColor?.sub};
+			theme.lightColor ? defaultTheme.lightColor?.blue.background : darkTheme.darkColor?.sub};
 		border-radius: 10px;
 
 		img {
@@ -290,7 +290,7 @@ const Payment = styled.div`
 		align-items: center;
 		width: 230px;
 		background-color: ${({ theme }) =>
-			theme === defaultTheme ? theme.lightColor?.blue.background : darkTheme.darkColor?.sub};
+			theme.lightColor ? defaultTheme.lightColor?.blue.background : darkTheme.darkColor?.sub};
 		height: 120px;
 		border-radius: 10px;
 	}

--- a/src/pages/user/OrderCheck.tsx
+++ b/src/pages/user/OrderCheck.tsx
@@ -84,7 +84,7 @@ function OrderCheck() {
 									{order.list.map((item, index) => (
 										<OrderMenuItem key={index}>
 											<div className="products-name">
-												<img src="/assets/user/IceCoffee.svg" alt="제품이미지" width={42} />
+												<img src={item.imgUrl} alt="제품이미지" width={42} />
 												<p>{item.menu}</p>
 											</div>
 											<p>{item.quantity}</p>

--- a/src/pages/user/OrderCheck.tsx
+++ b/src/pages/user/OrderCheck.tsx
@@ -10,6 +10,7 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { usedPointsState } from '../../state/PointState';
 import { Order } from '../../types/Order';
 import { orderListStateAtom } from '../../state/OrderListAtom';
+import Toast from '../../components/adminMode/Toast';
 
 function OrderCheck() {
 	const navigate = useNavigate();
@@ -18,6 +19,7 @@ function OrderCheck() {
 	const [orderList, setOrderList] = useRecoilState(orderListStateAtom);
 	const [isOpenAddPointModal, setAddPointModalOpen] = useState<boolean>(false);
 	const [isOpenUsePointUserModal, setUsePointUserModalOpen] = useState<boolean>(false);
+	const [toastMessage, setToastMessage] = useState<string | null>(null);
 
 	const toggleModal = (modalSetter: React.Dispatch<React.SetStateAction<boolean>>) => () => {
 		modalSetter((prevState) => !prevState);
@@ -46,12 +48,20 @@ function OrderCheck() {
 		setOrderList((prevOrders) =>
 			prevOrders.map((order) => (order.progress === '주문완료' ? { ...order, progress: '진행중' } : order)),
 		);
-		alert('결제되었습니다');
+		setToastMessage('결제되었습니다');
 		// 상태 초기화
 		setOrderList([]); // 주문 목록 초기화
 		setUsedPoints(0); // 사용된 포인트 초기화
 	};
+	useEffect(() => {
+		if (toastMessage) {
+			const timer = setTimeout(() => {
+				setToastMessage(null);
+			}, 3000); // 3초 후에 실행
 
+			return () => clearTimeout(timer);
+		}
+	}, [toastMessage]);
 	const totalOrderPay = computeTotalOrderAmount();
 	const TotalOrderPrice = totalOrderPay - (usedPoints || 0);
 
@@ -129,6 +139,7 @@ function OrderCheck() {
 							결제하기
 							<img src="/assets/user/buy.svg" />
 						</button>
+						{toastMessage && <Toast text={toastMessage} />}
 					</Payment>
 				</OrderTotalPriceContainer>
 			</Container>

--- a/src/pages/user/OrderCheck.tsx
+++ b/src/pages/user/OrderCheck.tsx
@@ -34,18 +34,17 @@ function OrderCheck() {
 	};
 
 	const handlePayment = async () => {
-		const ordersToUpdate = orderList.filter((order) => order.progress === '진행중');
+		const ordersToUpdate = orderList.filter((order) => order.progress === '주문완료');
 
 		for (const order of ordersToUpdate) {
 			const orderCollectionRef = collection(db, 'orderList');
 
 			// 새 문서 ID를 자동 생성하여 추가
-			const newDocRef = await addDoc(orderCollectionRef, { ...order, progress: '주문완료', totalOrderPay });
-			console.log(`Added document with ID ${newDocRef.id}`);
+			const newDocRef = await addDoc(orderCollectionRef, { ...order, progress: '진행중', totalOrderPay });
 		}
 
 		setOrderList((prevOrders) =>
-			prevOrders.map((order) => (order.progress === '진행중' ? { ...order, progress: '주문완료' } : order)),
+			prevOrders.map((order) => (order.progress === '주문완료' ? { ...order, progress: '진행중' } : order)),
 		);
 		alert('결제되었습니다');
 	};
@@ -79,7 +78,7 @@ function OrderCheck() {
 					</TableHead>
 					<Tbody>
 						{orderList
-							.filter((order) => order.progress === '진행중')
+							.filter((order) => order.progress === '주문완료')
 							.map((order) => (
 								<div key={order.id}>
 									{order.list.map((item, index) => (

--- a/src/pages/user/OrderCheck.tsx
+++ b/src/pages/user/OrderCheck.tsx
@@ -14,7 +14,7 @@ import { orderListStateAtom } from '../../state/OrderListAtom';
 function OrderCheck() {
 	const navigate = useNavigate();
 	const theme = useTheme();
-	const usedPoints = useRecoilValue(usedPointsState);
+	const [usedPoints, setUsedPoints] = useRecoilState(usedPointsState);
 	const [orderList, setOrderList] = useRecoilState(orderListStateAtom);
 	const [isOpenAddPointModal, setAddPointModalOpen] = useState<boolean>(false);
 	const [isOpenUsePointUserModal, setUsePointUserModalOpen] = useState<boolean>(false);
@@ -47,6 +47,9 @@ function OrderCheck() {
 			prevOrders.map((order) => (order.progress === '주문완료' ? { ...order, progress: '진행중' } : order)),
 		);
 		alert('결제되었습니다');
+		// 상태 초기화
+		setOrderList([]); // 주문 목록 초기화
+		setUsedPoints(0); // 사용된 포인트 초기화
 	};
 
 	const totalOrderPay = computeTotalOrderAmount();

--- a/src/pages/user/Start.tsx
+++ b/src/pages/user/Start.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { styled } from 'styled-components';
 import { isWaitingAvailableState } from '../../state/WaitingState';
+import { takeOutState } from '../../state/TakeOut';
 
 function Start() {
 	const navigate = useNavigate();
 	const isWaitingAvailable = useRecoilValue<boolean>(isWaitingAvailableState);
-
+	const [takeOut, setTakeOut] = useRecoilState(takeOutState);
 	return (
 		<StartWrapper>
 			<BackIconWrapper>
@@ -33,6 +34,7 @@ function Start() {
 					<TakeOutBox
 						onClick={() => {
 							navigate('/menu');
+							setTakeOut(false);
 						}}
 						aria-label="매장에서 먹고 가기 선택"
 					>
@@ -43,6 +45,7 @@ function Start() {
 				<TakeOutBox
 					onClick={() => {
 						navigate('/menu');
+						setTakeOut(true);
 					}}
 					aria-label="테이크 아웃 선택"
 				>

--- a/src/state/TakeOut.ts
+++ b/src/state/TakeOut.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const takeOutState = atom({
+	key: 'takeOutState',
+	default: false,
+});

--- a/src/types/Order.ts
+++ b/src/types/Order.ts
@@ -6,6 +6,7 @@ export interface Order {
 	progress: OrderProgress;
 	takeOut: boolean;
 	list: {
+		imgUrl: string;
 		menu: string;
 		quantity: number;
 		options: string;


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

## ✨ 구현 기능 명세
메뉴 주문 들어갔을때 테이크 아웃 true,false 결정
세자리수 컴마 함수 사용
메뉴리스트 들어갔을때 커피 카테고리 선택된 상태로
메뉴리스트 헤더 디크모드 클릭시 색상 변경
주문 내역 확인 이미지 각 메뉴 아이템 이미지에 맞게 수정

 포인트 500이하거나 횐갑 안되어있으면 toast 내보내기
 포인트  전액 누를때 포인트 사용 안변함 수정
메뉴아이템 선택하고 아무것도 안누르고 뒤로가기 눌렀을때 OrderCheck 에 남아 있음
메뉴 클릭안할시 주문확인페이지로 안넘어가야함

## 🎁 PR Point
색상코드 수정한게 제대로 한건지.. 
## 🕰 소요시간
4시간
## 😭 어려웠던 점
OrderCheck alert 창 Toast 로 바꿧는데 
UsePointUser 에선 왜 안뜨는지 모르겠습니다.. 
비동기로 때문에 그럴까요 ? 
원인을 못찾겠네요 ㅠ 


