### PR TITLE
[#118][🔨 REFACTOR] 매일 대기 번호 초기화 코드 수정

### DIFF
--- a/src/pages/user/Waiting.tsx
+++ b/src/pages/user/Waiting.tsx
@@ -39,6 +39,11 @@ function Waiting() {
 	//* 당일 날짜의 현재 대기 팀 수
 	const filteredWaitingNum = useMemo(() => filterTodayWaiting(currentData, 'waiting').length, [currentData]);
 
+	const todayWaitingNum = useMemo(
+		() => filterTodayWaiting(currentData, 'waiting').length + filterTodayWaiting(currentData, 'waited').length,
+		[currentData],
+	);
+
 	//* 대기 신청 시 필수 입력 값
 	const [waitingPersonNum, setWaitingPersonNum] = useState<number>(1);
 	const [decreaseDisable, setDecreaseDisable] = useState<boolean>(false);
@@ -92,7 +97,7 @@ function Waiting() {
 				if (firstWaitingData.docs.length === 0) {
 					localStorage.setItem('waitingNum', (0).toString());
 				} else {
-					localStorage.setItem('waitingNum', filteredWaitingNum.toString());
+					localStorage.setItem('waitingNum', todayWaitingNum.toString());
 				}
 			} catch (error) {
 				console.error('Error getting waiting data:', error);

--- a/src/pages/user/Waiting.tsx
+++ b/src/pages/user/Waiting.tsx
@@ -36,6 +36,8 @@ function Waiting() {
 	const storedWaitingNum = localStorage.getItem('waitingNum');
 	const waitingNum = storedWaitingNum ? parseInt(storedWaitingNum) : 1;
 
+	const [firstWaiting, setFirstWaiting] = useState<boolean>(true);
+
 	//* 당일 날짜의 현재 대기 팀 수
 	const filteredWaitingNum = useMemo(() => filterTodayWaiting(currentData, 'waiting').length, [currentData]);
 
@@ -91,6 +93,8 @@ function Waiting() {
 
 				if (firstWaitingData.docs.length === 0) {
 					localStorage.setItem('waitingNum', (0).toString());
+				} else {
+					localStorage.setItem('waitingNum', filteredWaitingNum.toString());
 				}
 			} catch (error) {
 				console.error('Error getting waiting data:', error);
@@ -98,13 +102,7 @@ function Waiting() {
 		};
 
 		getWaitingData();
-	}, []);
-
-	useEffect(() => {
-		if (currentData) {
-			localStorage.setItem('waitingNum', currentWaitingNum.toString());
-		}
-	}, [currentData, currentWaitingNum, waitingPersonNum]);
+	}, [currentWaitingNum, filteredWaitingNum]);
 
 	useEffect(() => {
 		if (waitingPersonNum === 1) {

--- a/src/pages/user/Waiting.tsx
+++ b/src/pages/user/Waiting.tsx
@@ -91,7 +91,6 @@ function Waiting() {
 
 				if (firstWaitingData.docs.length === 0) {
 					localStorage.setItem('waitingNum', (0).toString());
-					// setWaitingNum(0);
 				}
 			} catch (error) {
 				console.error('Error getting waiting data:', error);
@@ -100,6 +99,12 @@ function Waiting() {
 
 		getWaitingData();
 	}, []);
+
+	useEffect(() => {
+		if (currentData) {
+			localStorage.setItem('waitingNum', currentWaitingNum.toString());
+		}
+	}, [currentData, currentWaitingNum, waitingPersonNum]);
 
 	useEffect(() => {
 		if (waitingPersonNum === 1) {

--- a/src/pages/user/Waiting.tsx
+++ b/src/pages/user/Waiting.tsx
@@ -40,7 +40,10 @@ function Waiting() {
 	const filteredWaitingNum = useMemo(() => filterTodayWaiting(currentData, 'waiting').length, [currentData]);
 
 	const todayWaitingNum = useMemo(
-		() => filterTodayWaiting(currentData, 'waiting').length + filterTodayWaiting(currentData, 'waited').length,
+		() =>
+			filterTodayWaiting(currentData, 'waiting').length +
+			filterTodayWaiting(currentData, 'waited').length +
+			filterTodayWaiting(currentData, 'seated').length,
 		[currentData],
 	);
 
@@ -105,7 +108,7 @@ function Waiting() {
 		};
 
 		getWaitingData();
-	}, [currentWaitingNum, filteredWaitingNum]);
+	}, [currentWaitingNum, filteredWaitingNum, todayWaitingNum]);
 
 	useEffect(() => {
 		if (waitingPersonNum === 1) {

--- a/src/pages/user/Waiting.tsx
+++ b/src/pages/user/Waiting.tsx
@@ -36,8 +36,6 @@ function Waiting() {
 	const storedWaitingNum = localStorage.getItem('waitingNum');
 	const waitingNum = storedWaitingNum ? parseInt(storedWaitingNum) : 1;
 
-	const [firstWaiting, setFirstWaiting] = useState<boolean>(true);
-
 	//* 당일 날짜의 현재 대기 팀 수
 	const filteredWaitingNum = useMemo(() => filterTodayWaiting(currentData, 'waiting').length, [currentData]);
 


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

## ✨ 구현 기능 명세

- 처음 대기 신청 페이지에 들어갔을 땐, 기존 대기 번호의 수를 가져와 로컬스토리지에 저장하게 처리함.
- 기존 대기 번호가 존재한다면 기존 대기 번호의 수를, 기존 대기 번호가 존재하지 않는다면 waitingNum을 0으로 초기화함.
- 기존 대기 인원에서 취소나 착석완료로 대기 번호가 빠질 시의 경우도 로직 처리

