### PR TITLE
[#121][🔨 REFACTOR] 매출 관리 - 해당 날짜 데이터만 가져오는 코드 수정

### DIFF
--- a/src/pages/admin/SalesList.tsx
+++ b/src/pages/admin/SalesList.tsx
@@ -4,7 +4,7 @@ import { styled } from 'styled-components';
 import ManagementHeader from '../../components/adminMode/ManagementHeader';
 import { db } from '../../firebase/firebaseConfig';
 import { collection, getDocs } from 'firebase/firestore';
-import { changePriceFormat } from '../../utils/changeFormat';
+import { changePriceFormat, changeYYMMDD } from '../../utils/changeFormat';
 import { Order } from '../../types/Order';
 
 interface totalOrder extends Order {
@@ -19,7 +19,7 @@ interface DaySalesData {
 
 function SalesList() {
 	const currentDate = new Date();
-	const todayDate = currentDate.toISOString().split('T')[0];
+	const todayDate = changeYYMMDD(currentDate);
 	const [salesList, setSalesList] = useState<totalOrder[]>([]);
 	const [daySalesData, setDaySalesData] = useState<DaySalesData[]>([]);
 	const [displayDate, setDisplayDate] = useState(todayDate);
@@ -45,7 +45,7 @@ function SalesList() {
 		const salesByDate: { [date: string]: { salesData: totalOrder[]; totalPriceSum: number } } = {};
 
 		salesList.forEach((order) => {
-			const date = new Date(order.id).toISOString().split('T')[0];
+			const date = changeYYMMDD(new Date(order.id));
 			if (!salesByDate[date]) {
 				salesByDate[date] = { salesData: [], totalPriceSum: 0 };
 			}
@@ -66,14 +66,14 @@ function SalesList() {
 	const handlePreviousDay = () => {
 		const currentDate = new Date(displayDate);
 		currentDate.setDate(currentDate.getDate() - 1);
-		const previousDate = currentDate.toISOString().split('T')[0];
+		const previousDate = changeYYMMDD(currentDate);
 		setDisplayDate(previousDate);
 	};
 
 	const handleNextDay = () => {
 		const currentDate = new Date(displayDate);
 		currentDate.setDate(currentDate.getDate() + 1);
-		const nextDate = currentDate.toISOString().split('T')[0];
+		const nextDate = changeYYMMDD(currentDate);
 		setDisplayDate(nextDate);
 	};
 

--- a/src/utils/changeFormat.ts
+++ b/src/utils/changeFormat.ts
@@ -13,3 +13,11 @@ export const changeDateFormat = (numberDate: number) => {
 export const changePriceFormat = (price: string) => {
 	return price.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 };
+
+export const changeYYMMDD = (newDate: Date) => {
+	const year = newDate.getFullYear();
+	const month = (newDate.getMonth() + 1).toString().padStart(2, '0');
+	const day = newDate.getDate().toString().padStart(2, '0');
+
+	return `${year}-${month}-${day}`;
+};


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

## ✨ 구현 기능 명세
date타입의 날짜를 'yyyy-mm-dd'형식으로 바꿔서 사용했는데, 포맷을 바꾸는 코드에 문제가 있는지 특정 시간대 이후로만 날짜를 제대로 가져와서 'yyyy-mm-dd' 형식으로 바꿔주는 함수를 수정하였다. 테스트를 해보니 정상적으로 자정이 지났을 때 변경된 날짜에 따른 데이터를 잘 가져왔다.

## 🎁 PR Point
선택 날짜에 따라 해당되는 매출 데이터를 잘 가져오는지 체크

## 🕰 소요시간
약 30분

